### PR TITLE
v3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ package-lock.json
 
 build
 
+tmp
 *.tmp.ts
 
 .nesoi

--- a/examples/1_hello_world/main.ts
+++ b/examples/1_hello_world/main.ts
@@ -10,10 +10,8 @@ import { InlineApp } from '~/engine/apps/inline.app';
 // PS: External types are not available, but internal/inferred ones should work.
 
 const calcAverageJob = new JobBuilder('my_module', 'calc_average')
-    .messages($ => ({
-        '': {
-            values: $.float.array
-        }
+    .message('', $ => ({
+        values: $.list($.float)
     }))
     .input('@')
     .output.raw<number>()

--- a/examples/2_simple_project/modules/main/irrigate.job.ts
+++ b/examples/2_simple_project/modules/main/irrigate.job.ts
@@ -1,13 +1,10 @@
 import Nesoi from '../../nesoi';
 
 export default Nesoi.job('main::irrigate')
-    .messages($ => ({
-        '': {
-            plant: $.id('plant'),
-            volume: $.float
-        }
+    .message('', $ => ({
+        plant: $.id('plant'),
+        volume: $.float
     }))
-    .input('@')
     .assert($ => 
         $.msg.plant.color !== 'pink'
         || 'Can\'t irrigate pink plant, sorry.'

--- a/examples/3_sandbox/apps/bigrock.app.ts
+++ b/examples/3_sandbox/apps/bigrock.app.ts
@@ -34,6 +34,7 @@ export default new MonolythApp('bigrock', Nesoi)
                         state: 'idle',
                         jojo: {},
                         la2: 'rgb',
+                        simplelist: [1, 2, 3],
                         simpleobj: [{
                             a: 1,
                             b: true,
@@ -64,6 +65,7 @@ export default new MonolythApp('bigrock', Nesoi)
                         state: 'idle',
                         jojo: {},
                         la2: 'rgb',
+                        simplelist: [1, 2, 3],
                         simpleobj: [{
                             a: 1,
                             b: true,

--- a/examples/3_sandbox/lib/mana.ts
+++ b/examples/3_sandbox/lib/mana.ts
@@ -1,1 +1,10 @@
 export const MANA = 3;
+
+
+export function rule($: any) {
+    return $.msg.sim || 'Não';
+}
+
+export function rule2($: any) {
+    return $.msg.nao || 'Sim';
+}

--- a/examples/3_sandbox/modules/example/_externals.ts
+++ b/examples/3_sandbox/modules/example/_externals.ts
@@ -2,5 +2,6 @@ import Nesoi from '../../nesoi';
 
 export default Nesoi.externals('example')
     .bucket('irrigation::area')
+    .message('irrigation::send_water')
     // .job('');
     

--- a/examples/3_sandbox/modules/example/bigbox.bucket.ts
+++ b/examples/3_sandbox/modules/example/bigbox.bucket.ts
@@ -9,19 +9,20 @@ export default Nesoi.bucket('example::bigbox')
         amount: $.float,
         la: $.enum(['a','b','c'] as const),
         la2: $.enum('example::color_type'),
-        simpleobj: $.obj({
+        simplelist: $.list($.int),
+        simpleobj: $.list($.obj({
             a: $.int,
             b: $.boolean,
-            c: $.obj({
+            c: $.list($.obj({
                 d: $.float,
                 e: $.int
-            }).array
-        }).array,
-        kaka: $.obj({
+            }))
+        })),
+        kaka: $.list($.obj({
             lala: $.obj({
                 koko: $.boolean
             })
-        }).array.default([{
+        })).default([{
             lala: {
                 koko: true
             }
@@ -34,34 +35,37 @@ export default Nesoi.bucket('example::bigbox')
     }))
 
     .graph($ => ({
-        is_taught_by: $.one('bigbox', {
-            'id': { '.':'id' }
+        'a.$.b': $.one('bigbox', {
+            'simpleobj.1.a <=': 1,
+            'simplelist.# >=': 3,
+            'simplelist.* in': [{ '.':'simplelist.$0' }],
+            // 'state': { '$': 'oi.$0' }
         }),
-        other: $.one('circle', {
-            'id': { '.':'id' }
-        })
+        // other: $.one('circle', {
+        //     'id': { '.':'id' }
+        // })
     }))
-    .view('name_only', $ => ({
-        name: $.model('simpleobj', {
-            loco: $.graph('is_taught_by')
-        }),
-        coco: $.computed($ => 3),
-        deep: {
-            nococo: $.computed($ => -3),
-            level2: $.model('simpleobj', {
-                a: $.model('simpleobj.#.a')
-            })
-        }
-    }))
+    // .view('name_only', $ => ({
+    //     name: $.model('simpleobj', {
+    //         loco: $.graph('is_taught_by')
+    //     }),
+    //     coco: $.computed($ => 3),
+    //     deep: {
+    //         nococo: $.computed($ => -3),
+    //         level2: $.model('simpleobj', {
+    //             a: $.model('simpleobj.#.a')
+    //         })
+    //     }
+    // }))
     .view('family', $ => ({
-        first_clone: $.graph('other', 'round'),
+        first_clone: $.graph('a.$.b'),
         surname: $.computed($ => {
             const a: number = 123;
             return a + 456;
         }),
-        loco: $.view('name_only')
+        loco: $.model('simpleobj.*.a')
     }))
     .view('teste', $ => $.extend('family', {
-        kakaka: $.graph('is_taught_by'),
+        // kakaka: $.graph('is_taught_by'),
         lolo: $.view('family')
     }));

--- a/examples/3_sandbox/modules/example/bigbox.resource.ts
+++ b/examples/3_sandbox/modules/example/bigbox.resource.ts
@@ -55,6 +55,11 @@ export default Nesoi.resource('example::bigbox')
         })
     )
     .delete($ => $
+        // .input($ => ({}))
+        .extra($ => {
+            console.log('heyo');
+            return {}
+        })
         // .prepare($ => true)
         // .after($ => {
             

--- a/examples/3_sandbox/modules/example/everything.message.ts
+++ b/examples/3_sandbox/modules/example/everything.message.ts
@@ -3,23 +3,25 @@ import Nesoi from '../../nesoi';
 export default Nesoi.message('example::everything')
     .as('Bootstrap n1')
     .template($ => ({
-        prop_boolean: $.boolean.array.default([true, false]),
+        prop_boolean: $.list($.boolean).default([true, false]),
         prop_date: $.date,
         prop_datetime: $.datetime,
         prop_enum_1: $.enum('color_type'),
         prop_enum: $.enum('equipment_color'),
-        prop_float: $.float.or($.string),
+        prop_float: $.union($.float, $.string),
         prop_int: $.int
             .rule($ => $.value === 3 ? { set: 4 } : 'Invalid CPF'),
         prop_string: $.string,
         prop_bucket: $.id('bigbox'),
-        prop_obj: $.obj({
-            prop_obj_flat: $.int,
-            prop_obj_child: $.obj({
-                prop_obj_subchild: $.date
-            })
-        })
-            .or($.string),
+        prop_obj: $.union(
+            $.obj({
+                prop_obj_flat: $.int,
+                prop_obj_child: $.obj({
+                    prop_obj_subchild: $.date
+                })
+            }),
+            $.string
+        ),
         prop_dict: $.dict($.obj({
             papa: $.float
         })),

--- a/examples/3_sandbox/modules/example/kitchen.queue.ts
+++ b/examples/3_sandbox/modules/example/kitchen.queue.ts
@@ -1,9 +1,6 @@
 import Nesoi from '../../nesoi';
 
 export default Nesoi.queue('example::kitchen')
-    .messages($ => ({
-        wash: {
-            speed: $.float
-        }
-    }))
-    .input('@.wash');
+    .message('wash', $ => ({
+        speed: $.float
+    }));

--- a/examples/3_sandbox/modules/example/log_something.job.ts
+++ b/examples/3_sandbox/modules/example/log_something.job.ts
@@ -6,38 +6,36 @@ export default Nesoi.job('example::log_something')
     .scope('machine:walker')
     .authn('api')
 
-    .messages($ => ({
-        'trigger': {
-            lala: $.boolean,
-            prop_int: $.int,
-            kaka: $.obj({
-                into: $.int.rule($ => $.value > 3 || 'Nah'),
-                koko: $.id('bigbox')
-            }),
-            f: $.dict($.boolean)
-        },
-        '': {
-            joca: $.int.rule($ => $.value > 5 || 'Wow'),
-            f: $.dict($.boolean)
-        }
-        // 'response': {
-        //     lele: $.boolean,
-        //     ido: $.id('bigbox'),
-        //     koko: {
-        //         papa: $.id('bigbox')
-        //     }
-        // },
+    .message('trigger', $ => ({
+        lala: $.boolean,
+        prop_int: $.int,
+        kaka: $.obj({
+            into: $.int.rule($ => $.value > 3 || 'Nah'),
+            koko: $.id('bigbox')
+        }),
+        f: $.dict($.boolean)
     }))
 
+    .message('', $ => ({
+        joca: $.int.rule($ => $.value > 5 || 'Wow'),
+        f: $.dict($.boolean)
+    }))
+
+// .message('response', $ => ({
+//         lele: $.boolean,
+//         ido: $.id('bigbox'),
+//         koko: {
+//             papa: $.id('bigbox')
+//         }
+// }))
+
     .input(
-        '@.trigger',
-        'everything',
-        '@'
+        'everything'
     )
     .output.raw<boolean>()
 
     .extra($ => ({
-        l: $.obj.reco,
+        l: $.msg.$,
         lala2: $.msg.$ === 'everything'
             ? $.msg.prop_boolean
             : $.msg.f

--- a/examples/3_sandbox/modules/example/something_else.message.ts
+++ b/examples/3_sandbox/modules/example/something_else.message.ts
@@ -1,3 +1,4 @@
+import * as mana from '../../lib/mana';
 import Nesoi from '../../nesoi';
 
 export default Nesoi.message('example::something_else')
@@ -7,10 +8,14 @@ export default Nesoi.message('example::something_else')
         batata1: $.enum('equipment_color'),
         batata2: $.enum(['a', 'b', 'c'] as const),
         batata3: $.enum({ a: 1 as const, b: 2 as const, c: 3 as const }),
-        banana: $.id('circle'),
+        banana: $.list($.id('circle')).rule($ => {
+            return $.msg.batata1 === 'blue' || 'Não';
+        }).optional,
         joao: $.obj({
             kaka: $.id('circle').rule($ => {
                 return 'oi'
             })
-        })
+        }),
+        send: $.msg('irrigation::send_water', {}).rule(mana.rule).optional,
+        attachment: $.string.rule(mana.rule)
     }));

--- a/examples/3_sandbox/modules/irrigation/send_water.message.ts
+++ b/examples/3_sandbox/modules/irrigation/send_water.message.ts
@@ -1,8 +1,9 @@
+import { rule2 } from '../../lib/mana';
 import Nesoi from '../../nesoi';
 
 export default Nesoi.message('irrigation::send_water')
     .as('Send Water')
     .template($ => ({
         area: $.id('area'),
-        box: $.id('example::bigbox').optional,
+        box: $.id('example::bigbox').rule(rule2)
     }));

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
     moduleNameMapper: {
         '~/(.*)': '<rootDir>/src/$1',
         'nesoi/tools/(.*)': '<rootDir>/tools/$1',
-    }
+    },
+    watchPathIgnorePatterns: ['tmp']
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nesoi",
-  "version": "3.0.21",
+  "version": "3.1.0",
   "description": "Declarative framework for data-driven applications",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "build": "tspc -p tsconfig.build.json",
     "bundle": "npx tsx scripts/bundle",
     "lint": "eslint .",
-    "test": "jest test --runInBand --watch",
+    "test": "jest test --maxWorkers=1 --watch",
     "test:types": "tsd",
     "mk:jsdoc": "jsdoc -c jsdoc.json"
   },

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -19,18 +19,12 @@ async function main() {
     Console.step('(Step 2) Transpile TypeScript source files')
     await Shell.cmd('.', 'npm run build')
 
-    Console.step('(Step 3) Run Syntax Typing Tests')
-    await Shell.cmd('.', 'npx tsd')
-
-    Console.step('(Step 4) Run Unit Tests')
-    await Shell.cmd('.', 'npx jest test/engine test/elements --verbose')
-
-    Console.step('(Step 5) Rename "src" folder to "lib"')
+    Console.step('(Step 3) Rename "src" folder to "lib"')
     const oldLibPath = path.resolve('.', 'build', 'src');
     const newLibPath = path.resolve('.', 'build', 'lib');
     fs.renameSync(oldLibPath, newLibPath);
 
-    Console.step('(Step 6) Replace "src" by "lib" on tools')
+    Console.step('(Step 4) Replace "src" by "lib" on tools')
     const compileToolPath = path.resolve('.', 'build', 'tools', 'compile.js');
     File.replaceInContent(compileToolPath, /require\("\.\.\/src\//g, 'require("../lib/');
     const dotenvToolPath = path.resolve('.', 'build', 'tools', 'dotenv.js');
@@ -40,12 +34,21 @@ async function main() {
     const joaquinMockToolTypePath = path.resolve('.', 'build', 'tools', 'joaquin', 'mock.d.ts');
     File.replaceInContent(joaquinMockToolTypePath, /from "\.\.\/\.\.\/src\//g, 'from "../../lib/');
 
+    Console.step('(Step 5) Run Syntax Typing Tests')
+    await Shell.cmd('.', 'npx tsd')
+
+    Console.step('(Step 6) Run Unit Tests')
+    await Shell.cmd('.', 'npx jest test/engine test/elements --verbose')
+
+    Console.step('(Step 7) Run Compiler Unit Tests')
+    await Shell.cmd('.', 'npx jest test/compiler')
+
     // Console.step('(Step 7) Copy "template" folder to build')
     // const sourceTemplatesPath = path.resolve('.', 'tools', 'bootstrap', 'templates');
     // const targetTemplatesPath = path.resolve('.', 'build', 'tools', 'bootstrap', 'templates');
     // fs.cpSync(sourceTemplatesPath, targetTemplatesPath, { recursive: true });
 
-    Console.step('(Step 7) Include package.json file on build/');
+    Console.step('(Step 8) Include package.json file on build/');
     const packageJson = JSON.parse(fs.readFileSync('package.json').toString());
     delete packageJson['scripts']
     delete packageJson['files']
@@ -59,7 +62,7 @@ async function main() {
     const buildPackageJson = path.resolve('.', 'build', 'package.json');
     fs.writeFileSync(buildPackageJson, JSON.stringify(packageJson, undefined, 4));
 
-    Console.step('(Step 8) Include README.md file on build/');
+    Console.step('(Step 9) Include README.md file on build/');
     const readme = path.resolve('.', 'README.md')
     const buildReadme = path.resolve('.', 'build', 'README.md')
     fs.copyFileSync(readme, buildReadme);

--- a/src/compiler/apps/monolyth/stages/4_dump_modules_stage.ts
+++ b/src/compiler/apps/monolyth/stages/4_dump_modules_stage.ts
@@ -51,6 +51,14 @@ export class DumpModulesStage {
                 }
                 str += '\n      },';
             }
+            if (Object.keys(externals.messages).length) {
+                str += '\n      messages: {';
+                for (const b in externals.messages) {
+                    const dep = externals.messages[b]
+                    str += `\n        '${b}': ${JSON.stringify(dep, undefined, 2).replace(/\n/g,'\n        ')},`;
+                }
+                str += '\n      },';
+            }
             if (Object.keys(externals.jobs).length) {
                 str += '\n      jobs: {\n';
                 for (const b in externals.jobs) {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -10,9 +10,9 @@ import { BuildSchemasStage } from './stages/4_build_schemas_stage';
 import { InjectTSStage } from './stages/5_inject_ts_stage';
 import { BuildElementsStage } from './stages/6_build_elements_stage';
 import { DumpStage } from './stages/7_dump_stage';
+import { DiagnoseStage } from './stages/8_diagnose_stage';
 import Console from '~/engine/util/console';
 import { Log } from '~/engine/util/log';
-import { DiagnoseStage } from './stages/8_diagnose_stage';
 import fs from 'fs';
 
 export type CompilerConfig = {

--- a/src/compiler/elements/element.ts
+++ b/src/compiler/elements/element.ts
@@ -59,7 +59,8 @@ export abstract class Element<T extends AnyElementSchema> {
 
     private bridgeImports(): string {
         let imports = '';
-        for (const imp of this.bridge?.imports || []) {
+        const uniqueImports = new Set(this.bridge?.imports || [])
+        for (const imp of uniqueImports) {
             imports += imp + '\n';
         }
         return imports;

--- a/src/compiler/elements/externals.element.ts
+++ b/src/compiler/elements/externals.element.ts
@@ -44,6 +44,9 @@ export class ExternalsElement extends Element<$Externals> {
         Object.values(this.schema.buckets).forEach(ref => {
             externalModules.add(ref.module);
         })
+        Object.values(this.schema.messages).forEach(ref => {
+            externalModules.add(ref.module);
+        })
         Object.values(this.schema.jobs).forEach(ref => {
             externalModules.add(ref.module);
         })

--- a/src/compiler/elements/queue.element.ts
+++ b/src/compiler/elements/queue.element.ts
@@ -6,7 +6,7 @@ export class QueueElement extends Element<$Queue> {
 
     protected prepare() {
         this.schema['#authn'] = Element.Any;
-        this.schema['#input'] = Element.Any;
+        this.schema['#input'] = Element.Never;
         this.schema['#output'] = Element.Any;
     }
 

--- a/src/compiler/helpers/dump_helpers.ts
+++ b/src/compiler/helpers/dump_helpers.ts
@@ -6,6 +6,16 @@ type TransformTypes = {
 
 export class DumpHelpers {
 
+    public static dumpUnionType(types: TypeAsObj[]): string {
+        if (types.length < 2) return this.dumpType(types[0]);
+        return '(' + types.map(t => this.dumpType(t)).join(' | ') + ')';
+    }
+
+    public static dumpIntersectionType(types: TypeAsObj[]): string {
+        if (types.length < 2) return this.dumpType(types[0]);
+        return '(' + types.map(t => this.dumpType(t)).join(' | ') + ')';
+    }
+
     public static dumpType(type: TypeAsObj, d = 0): string {
         const pad0 = '    '.repeat(d);
         const pad1 = '    '.repeat(d+1);
@@ -118,9 +128,9 @@ export class DumpHelpers {
     private static dumpFunction(fn: (...args: any[]) => any, padding = '') {
 
         // Functions should have been replaced by { __fn: ... } by the Compiler,
-        // if any is missed, this flag causes a typescript error when compiling.
+        // if not, we try to use the JS version.
 
-        return `/* TS BRIDGE ERROR: function not properly extracted from source. Function: ${fn.toString()} */`;
+        return `/* TS BRIDGE WARN: function not properly extracted from source. Attempting JS version (imports will not work) */ (${fn.toString()}) as any`;
     }
 
 

--- a/src/compiler/stages/4_build_schemas_stage.ts
+++ b/src/compiler/stages/4_build_schemas_stage.ts
@@ -28,6 +28,17 @@ export class BuildSchemasStage {
                 return;
             }
 
+            // Accummulate imports from depencies
+            // (Given that dependencies are built in order)
+            node.bridge ??= { imports: [] };
+            node.bridge.imports ??= [];
+            for (const dep of node.dependencies) {
+                // If a dependency is inline and the node is it's root,
+                // they already share imports.
+                if (dep.node.root == node) continue;
+                node.bridge.imports.push(...(dep.node.bridge?.imports || []));
+            }
+
             // Inline nodes are built by their root builder
             if (node.isInline) { return; }
 

--- a/src/compiler/stages/5_inject_ts_stage.ts
+++ b/src/compiler/stages/5_inject_ts_stage.ts
@@ -21,9 +21,11 @@ export class InjectTSStage {
 
         const { tree } = this.compiler;
         const nodes = tree.allNodes();
-
-        TSBridgeInject.inject(this.compiler, nodes);
-
+        tree.traverse('inject', node => {
+            TSBridgeInject.inject(this.compiler, nodes, node);
+            return Promise.resolve();
+        })
+        
         const t = new Date().getTime();
         Log.debug('compiler', 'stage.inject_ts', `[t: ${(t-t0)/1000} ms]`);
         Log.trace('compiler', 'stage.inject_ts', 'Finished injecting TS code');

--- a/src/compiler/stages/7_dump_stage.ts
+++ b/src/compiler/stages/7_dump_stage.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
+import path from 'path';
 import { Compiler } from '../compiler';
 import { ObjTypeAsObj } from '../elements/element';
 import { CompilerModule } from '../module';
 import { Log } from '~/engine/util/log';
 import { NameHelpers } from '../helpers/name_helpers';
-import path from 'path';
 import { ExternalsElement } from '../elements/externals.element';
 import { $Dependency } from '~/engine/dependency';
 import { BucketElement } from '../elements/bucket.element';
@@ -242,6 +242,12 @@ export class DumpStage {
             }
             Object.entries((externals as ExternalsElement).schema.buckets).forEach(([tag, ref]) => {
                 type.buckets[tag] = $Dependency.typeName(ref, module.lowName)
+            })
+            if (!type.messages) {
+                type.messages = {};
+            }
+            Object.entries((externals as ExternalsElement).schema.messages).forEach(([tag, ref]) => {
+                type.messages[tag] = $Dependency.typeName(ref, module.lowName)
             })
             if (!type.jobs) {
                 type.jobs = {};

--- a/src/compiler/treeshake.ts
+++ b/src/compiler/treeshake.ts
@@ -31,12 +31,14 @@ export class Treeshake {
         const b = node.builder as any;
         const $b = b.$b as AnyExternalsBuilder['$b'];
         const buckets = b.buckets as AnyExternalsBuilder['buckets'];
+        const messages = b.messages as AnyExternalsBuilder['messages'];
         const jobs = b.jobs as AnyExternalsBuilder['jobs'];
 
         Log.trace('compiler', 'treeshake', `${'  '.repeat(depth)} └ Treeshaking node ${scopeTag($b as any, node.name)}`);
 
         node.dependencies = [
             ...Object.values(buckets),
+            ...Object.values(messages),
             ...Object.values(jobs)
         ];
         node.dependencies = this.cleanNodeDependencies(node);
@@ -187,13 +189,13 @@ export class Treeshake {
             }
         }
 
-        // Inlines have a dependency on their parent node
+        // Inlines are a dependency of their parent node
         const inlines = [..._inlineNodes, ...nestedInlines];
         inlines.forEach(inline => {
-            inline.dependencies.push(new $Dependency(
-                node.module,
-                node.type,
-                node.name
+            dependencies.push(new $Dependency(
+                inline.module,
+                inline.type,
+                inline.name
             ))
         });
 

--- a/src/compiler/typescript/bridge/extract.ts
+++ b/src/compiler/typescript/bridge/extract.ts
@@ -16,9 +16,7 @@ export class TSBridgeExtract {
             }
             return;
         }
-        const imports = tsCompiler.extractImports(node.filepath, {
-            ignore: [] // TODO: ignore space file
-        });
+        const imports = tsCompiler.extractImports(node.filepath);
 
         if (imports.length) {
             Log.debug('compiler', 'bridge.extract', `Extracted TS imports from ${node.filepath}`, imports)
@@ -86,151 +84,99 @@ export class TSBridgeExtract {
 
         if (node.builder.$b === 'message') {
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'message.*.template.0.return.**.rule.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'message.*.template.0.return.*.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
+            }) as tsFnQueryResult[]);
+            functions.push(...tsCompiler.query(node.filepath, {
+                query: 'message.*.template.0.return.*.{~.#.*?}.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
         }          
 
         if (node.builder.$b === 'job') {
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'job.*.messages.0.return.*.**.rule.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'job.*.message.1.return.*.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'job.*.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'job.*.message.1.return.*.{~.#.*?}.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'job.*.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'job.*.method.0',
+                query: 'job.*.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
         }          
 
         if (node.builder.$b === 'resource') {
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.create.0.return.input.0.return.**.rule.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.create.0.return.input.0.return.*.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.create.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.create.0.return.input.0.return.*.{~.#.*?}.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.create.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.create.0.return.prepare.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.create.0.return.after.0',
+                query: 'resource.*.create.0.return.extra|assert|prepare|after.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
             
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.update.0.return.input.0.return.**.rule.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.update.0.return.input.0.return.*.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.update.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.update.0.return.input.0.return.*.{~.#.*?}.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.update.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.update.0.return.prepare.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.update.0.return.after.0',
+                query: 'resource.*.update.0.return.extra|assert|prepare|after.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
             
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.delete.0.return.input.0.return.**.rule.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.delete.0.return.input.0.return.*.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.delete.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
+                query: 'resource.*.delete.0.return.input.0.return.*.{~.#.*?}.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.delete.0.return.assert.0',
+                query: 'resource.*.delete.0.return.extra|assert|prepare|after.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.delete.0.return.prepare.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'resource.*.delete.0.return.after.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);            
+            }) as tsFnQueryResult[]);          
         }          
 
 
         if (node.builder.$b === 'machine') {
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.messages.0.return.*.**.rule.0',
+                query: 'machine.*.message.1.return.**.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
+            }) as tsFnQueryResult[]);
+            functions.push(...tsCompiler.query(node.filepath, {
+                query: 'machine.*.message.1.return.{**.obj.0}.**.rule.0',
+                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression, ts.SyntaxKind.PropertyAccessExpression]
+            }) as tsFnQueryResult[]);
+
+            functions.push(...tsCompiler.query(node.filepath, {
+                query: 'machine.*.{state.1.return}.beforeEnter.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
 
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeEnter.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeEnter.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeEnter.0.return.method.0',
+                query: 'machine.*.{state.1.return}.afterEnter.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
 
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterEnter.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterEnter.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterEnter.0.return.method.0',
+                query: 'machine.*.{state.1.return}.beforeLeave.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
 
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeLeave.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeLeave.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.beforeLeave.0.return.method.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterLeave.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterLeave.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.afterLeave.0.return.method.0',
+                query: 'machine.*.{state.1.return}.afterLeave.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
 
@@ -245,27 +191,11 @@ export class TSBridgeExtract {
             }) as tsFnQueryResult[]);
 
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.runJob.0.return.extra.0',
+                query: 'machine.*.{state.1.return}.transition.1.return.runJob.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
             functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.{else.0.return}.runJob.0.return.extra.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.runJob.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.{else.0.return}.runJob.0.return.assert.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.runJob.0.return.method.0',
-                expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
-            }) as tsFnQueryResult[]);
-            functions.push(...tsCompiler.query(node.filepath, {
-                query: 'machine.*.{state.1.return}.transition.1.return.{else.0.return}.runJob.0.return.method.0',
+                query: 'machine.*.{state.1.return}.transition.1.return.{else.0.return}.runJob.0.return.extra|assert|method.0',
                 expectedKinds: [ts.SyntaxKind.FunctionExpression, ts.SyntaxKind.ArrowFunction, ts.SyntaxKind.Identifier, ts.SyntaxKind.CallExpression]
             }) as tsFnQueryResult[]);
             

--- a/src/elements/blocks/block.builder.ts
+++ b/src/elements/blocks/block.builder.ts
@@ -1,7 +1,6 @@
 import { $Module, $Space } from '~/schema';
 import { $BlockOutput, $BlockType } from './block.schema';
-import { MessageTemplateDef, MultiMessageTemplateDef } from '~/elements/entities/message/template/message_template.builder';
-import { MessageTemplateFieldFactory } from '~/elements/entities/message/template/message_template_field.builder';
+import { MessageTemplateDef } from '~/elements/entities/message/template/message_template.builder';
 import { MessageBuilder } from '~/elements/entities/message/message.builder';
 import { $Dependency, BuilderNode } from '~/engine/dependency';
 import { NameHelpers } from '~/compiler/helpers/name_helpers';
@@ -50,7 +49,6 @@ export abstract class BlockBuilder<
         Def extends MessageTemplateDef<Space, Module, Name>
     >(name: Name, def: Def) {
         const msgName = `${this.name}${name.length ? ('.'+name) : ''}`;
-        this._inputMsgs.push(new $Dependency(this.module, 'message', msgName))
         const builder = new MessageBuilder<any,any,any>(this.module, msgName)
             .template(def);
         this._inlineNodes.push(new BuilderNode({
@@ -63,39 +61,6 @@ export abstract class BlockBuilder<
             dependencies: [] // This is added later by Treeshake.*()
         }));
 
-        const dep = new $Dependency(this.module, 'message', msgName);
-        this._inputMsgs.push(dep);
-        return this as unknown;
-    }
-
-    /**
-     * @deprecated
-     * Inline messages. These messages are exposed to the module,
-     * with a name prefixed by the block name.
-     * @param def A method which takes a field factory as input and outputs a template builder
-     * @returns The Builder, for call-chaining
-     */
-    /** @deprecated Use `.message` instead. Will be removed on 3.1 */
-    protected messages<
-        Def extends MultiMessageTemplateDef<Space, Module>
-    >(def: Def) {
-        const factory = new MessageTemplateFieldFactory<any, any, any>(this.module);
-        const schema = def(factory);
-        for (const key in schema) {
-            const name = `${this.name}${key.length ? ('.'+key) : ''}`;
-            this._inputMsgs.push(new $Dependency(this.module, 'message', name))
-            const builder = new MessageBuilder<any,any,any>(this.module, name)
-                .template(() => schema[key]);
-            this._inlineNodes.push(new BuilderNode({
-                module: this.module,
-                type: 'message',
-                name,
-                builder,
-                isInline: true,
-                filepath: [], // This is added later by Treeshake.blockInlineNodes()
-                dependencies: [] // This is added later by Treeshake.*()
-            }));
-        }
         return this as unknown;
     }
 

--- a/src/elements/edge/externals/externals.builder.ts
+++ b/src/elements/edge/externals/externals.builder.ts
@@ -36,6 +36,7 @@ export class ExternalsBuilder<
     public name = '*';
 
     private buckets: Record<string, $Dependency> = {};
+    private messages: Record<string, $Dependency> = {};
     private jobs: Record<string, $Dependency> = {};
     private machines: Record<string, $Dependency> = {};
 
@@ -51,6 +52,14 @@ export class ExternalsBuilder<
         return this;
     }
     
+    message<
+        M extends Exclude<keyof Space['modules'], ModuleName>,
+        B extends keyof Space['modules'][M]['messages']
+    >(ref: `${M & string}::${B & string}`) {
+        this.messages[ref] = new $Dependency(this.module, 'message', ref);
+        return this;
+    }
+
     job<
         M extends Exclude<keyof Space['modules'], ModuleName>,
         B extends keyof Space['modules'][M]['jobs']
@@ -78,6 +87,7 @@ export class ExternalsBuilder<
         node.schema = new $Externals(
             node.module,
             node.builder.buckets,
+            node.builder.messages,
             node.builder.jobs,
             node.builder.machines
         );

--- a/src/elements/edge/externals/externals.schema.ts
+++ b/src/elements/edge/externals/externals.schema.ts
@@ -10,12 +10,14 @@ export class $Externals {
     constructor(
         public name: string,
         public buckets: Record<string, $Dependency> = {},
+        public messages: Record<string, $Dependency> = {},
         public jobs: Record<string, $Dependency> = {},
         public machines: Record<string, $Dependency> = {}
     ) {}
 
     public static merge(to: $Externals, from: $Externals) {
         Object.assign(to.buckets, from.buckets);
+        Object.assign(to.messages, from.messages);
         Object.assign(to.jobs, from.jobs);
         Object.assign(to.machines, from.machines);
     }

--- a/src/elements/entities/bucket/adapters/memory.nql.ts
+++ b/src/elements/entities/bucket/adapters/memory.nql.ts
@@ -79,7 +79,7 @@ export class MemoryNQLRunner extends NQLRunner {
             if (pagination.returnTotal) {
                 totalItems = output.length;
             }
-            if (pagination.page || pagination.perPage) {
+            if (pagination.page !== undefined || pagination.perPage !== undefined) {
                 const a = ((pagination.page || 1)-1) * (pagination.perPage || 10);
                 const b = a + (pagination.perPage || 10);
                 output = output.slice(a, b);

--- a/src/elements/entities/bucket/bucket.builder.ts
+++ b/src/elements/entities/bucket/bucket.builder.ts
@@ -13,7 +13,7 @@ import { $BucketGraphLinksInfer } from './graph/bucket_graph.infer';
 import { $BucketGraph } from './graph/bucket_graph.schema';
 import { $Dependency, ResolvedBuilderNode } from '~/engine/dependency';
 import { ModuleTree } from '~/engine/tree';
-import { BucketFieldpathInfer, BucketModelInfer } from './model/bucket_model.infer';
+import { BucketModelpathInfer, BucketModelInfer, BucketQuerypathInfer } from './model/bucket_model.infer';
 import { Overlay } from '~/engine/util/type';
 import { $ConstantEnum, $Constants } from '../constants/constants.schema';
 import { NesoiError } from '~/engine/data/error';
@@ -64,7 +64,8 @@ export class BucketBuilder<
     model<
         Def extends BucketModelDef<Space, Module>,
         Obj = BucketModelInfer<Def>,
-        Fieldpath extends {} = BucketFieldpathInfer<Def>
+        Modelpath extends {} = BucketModelpathInfer<Def>,
+        Querypath extends {} = BucketQuerypathInfer<Def>
     >($: Def) {
         const fieldBuilder = new BucketModelFieldFactory(this.module);
         const fields = $(fieldBuilder);
@@ -72,7 +73,8 @@ export class BucketBuilder<
         this._model = BucketModelBuilder.build(builder);
         type _Bucket = Overlay<Bucket, {
             '#data': Obj & NesoiObj,
-            '#fieldpath': Fieldpath
+            '#modelpath': Modelpath
+            '#querypath': Querypath
         }>
         return this as unknown as BucketBuilder<
             Space,
@@ -119,7 +121,7 @@ export class BucketBuilder<
         $: Def
     ) {
         const view = new BucketViewBuilder(name as string);
-        view.fields($);
+        view.fields($ as never);
         this._views[name as string] = view;
         type ViewFields = $BucketViewFieldsInfer<ReturnType<Def>>
         type Data = $BucketViewDataInfer<ReturnType<Def>>

--- a/src/elements/entities/bucket/bucket.schema.ts
+++ b/src/elements/entities/bucket/bucket.schema.ts
@@ -21,7 +21,8 @@ export class $Bucket {
     public $t = 'bucket' as const;
     public '#data'!: NesoiObj;
     public '#composition': Record<string, { bucket: $Bucket, many: boolean, optional: boolean }>;
-    public '#fieldpath': {};
+    public '#modelpath': {};
+    public '#querypath': {};
     public '#defaults': Record<string, any>
 
     constructor(

--- a/src/elements/entities/bucket/graph/bucket_graph.infer.ts
+++ b/src/elements/entities/bucket/graph/bucket_graph.infer.ts
@@ -1,10 +1,14 @@
 import { Overlay } from '~/engine/util/type';
 import { $BucketGraphLink } from './bucket_graph.schema';
-import { BucketGraphLinkBuilder, BucketGraphLinkBuilders } from './bucket_graph_link.builder';
+import { BucketGraphLinkBuilders } from './bucket_graph_link.builder';
+
+type Replace<T extends string>
+    = T extends `${infer L}$${infer R}`
+    ? `${L}${string}${Replace<R>}`
+    : T
+
 
 export type $BucketGraphLinksInfer<Builders extends BucketGraphLinkBuilders> = {
-    [K in keyof Builders]: 
-        Builders[K] extends BucketGraphLinkBuilder<any, any, infer Y>
-            ? Overlay<$BucketGraphLink, { '#bucket': Y, '#data': Y['#data'] }>
-            : never;
+    [K in keyof Builders as Replace<K & string>]: 
+        Overlay<$BucketGraphLink, { '#bucket': Builders[K]['#other'], '#data': Builders[K]['#other']['#data'] }>
 }

--- a/src/elements/entities/bucket/graph/bucket_graph_link.builder.ts
+++ b/src/elements/entities/bucket/graph/bucket_graph_link.builder.ts
@@ -13,8 +13,8 @@ type BucketGraphLinkPath<
     SelfBucket extends $Bucket,
     OtherBucket extends $Bucket
 > = {
-    self?: keyof SelfBucket['#fieldpath'],
-    other?: keyof OtherBucket['#fieldpath'],
+    self?: keyof SelfBucket['#modelpath'],
+    other?: keyof OtherBucket['#modelpath'],
 }
 
 /*
@@ -29,7 +29,7 @@ type BucketGraphLinkPath<
 export class BucketGraphLinkFactory<
     Module extends $Module,
     SelfBucket extends $Bucket,
-    Fieldpaths = NoInfer<SelfBucket['#fieldpath']>
+    Fieldpaths = NoInfer<SelfBucket['#modelpath']>
 > {
 
     private alias?: string;
@@ -95,6 +95,7 @@ export class BucketGraphLinkBuilder<
     SelfBucket extends $Bucket,
     OtherBucket extends $Bucket
 > {
+    public '#other': OtherBucket
 
     private _optional = false;
 

--- a/src/elements/entities/bucket/model/bucket_model.builder.ts
+++ b/src/elements/entities/bucket/model/bucket_model.builder.ts
@@ -47,5 +47,5 @@ export type BucketModelDef<
     Space extends $Space,
     Module extends $Module
 > = ($: BucketModelFieldFactory<Space, Module>) => {
-    id: BucketModelFieldBuilder<Module, any>
+    id: BucketModelFieldBuilder<Module, any, any, any, any, any>
 } & BucketModelFieldBuilders<Module>

--- a/src/elements/entities/bucket/model/bucket_model.convert.ts
+++ b/src/elements/entities/bucket/model/bucket_model.convert.ts
@@ -17,7 +17,8 @@ export function convertToView<
     model: Model,
     name: string,
     fields: $BucketModelFields = model.fields,
-    path?: string
+    path?: string,
+    depth = 0
 ) {
     const view = new BucketViewBuilder(name);
     const convertFields = (fields: $BucketModelFields) => {
@@ -31,7 +32,7 @@ export function convertToView<
             
             const builder = $.model(key as never);
             const graph = new $BucketGraph();
-            viewFields[f] = BucketViewFieldBuilder.build(builder, model, graph, {}, field.name);
+            viewFields[f] = BucketViewFieldBuilder.build(builder, model, graph, {}, field.name, depth);
         }
         return viewFields;
     };
@@ -60,14 +61,11 @@ export function convertToMessage<
             field.type,
             field.name,
             field.alias,
-            field.alias,
             field.path,
             field.path,
-            field.array,
             field.required,
             undefined,
             false,
-            [],
             [],
             {
                 enum: field.meta?.enum ? {
@@ -75,8 +73,7 @@ export function convertToMessage<
                     dep: field.meta.enum.dep ? new $Dependency(module,'constants', `${field.meta.enum.dep.module}::${field.meta.enum.dep.name}`) : undefined
                 } : undefined
             },
-            field.children ? convertFields(field.children, include, exclude) : undefined,
-            field.or ? convertField(field.or) : undefined
+            field.children ? convertFields(field.children, include, exclude) : undefined
         )
     }
     const convertFields = (fields: $BucketModelFields, include: string[]=[], exclude: string[]=[], root='') => {

--- a/src/elements/entities/bucket/model/bucket_model.infer.ts
+++ b/src/elements/entities/bucket/model/bucket_model.infer.ts
@@ -1,32 +1,104 @@
-import { MergeUnion } from '~/engine/util/type';
+import { UnionToIntersection } from '~/engine/util/type';
 import { BucketModelDef } from './bucket_model.builder';
-import { BucketModelFieldBuilder, BucketModelFieldBuilders } from './bucket_model_field.builder';
+import { AnyBucketModelFieldBuilder, BucketModelFieldBuilders } from './bucket_model_field.builder';
 
 export type BucketModelObjInfer<
-    Builders extends BucketModelFieldBuilders<any>
+    Fields extends BucketModelFieldBuilders<any>,
+    Prefix = ''
 > = {
-    [K in keyof Builders]: Builders[K] extends BucketModelFieldBuilder<any, any, any, infer X>
-        ? X
-        : BucketModelObjInfer<Builders[K] & BucketModelFieldBuilders<any>>
+    // Required fields
+    [K in keyof Fields as 
+        Fields[K]['#optional'][1] extends true ? never : `${Prefix&string}${K&string}`
+    ]: Fields[K]['#output']
+} & {
+    // Optional fields
+    [K in keyof Fields as 
+        Fields[K]['#optional'][1] extends true ? `${Prefix&string}${K&string}` : never
+    ]?: Fields[K]['#output']
 }
 
 export type BucketModelInfer<
     Def extends BucketModelDef<any, any>
 > = BucketModelObjInfer<ReturnType<Def>>
 
-/* */
+/* Modelpath */
 
-export type BucketFieldpathObjInfer<
-    Builders extends BucketModelFieldBuilders<any>,
-    Prefix extends string
-> = MergeUnion<{
-    [K in keyof Builders]: Builders[K] extends BucketModelFieldBuilder<any, any, any, any, infer X>
-        ? { [J in keyof X as `${Prefix}${K & string}${J & string}`]: X[J]}
-        // {} syntax doesnt support dynamic fieldpaths
-        : never//BucketFieldpathObjInfer<Builders[K] & BucketModelFieldBuilders<any>, `${Prefix}.${K}`>
+type A = { a: 1, b: 2 } | { a: 3, c: 4 }
+type B = keyof A
+// type C = [B & keyof A]
+
+
+type BucketModelpathRawInfer<
+    Builders extends BucketModelFieldBuilders<any>
+> = UnionToIntersection<{
+    [K in keyof Builders]: {
+        [J in keyof Builders[K]['#modelpath'] as `${K & string}${J & string}`]: Builders[K]['#modelpath'][J]
+    }
 }[keyof Builders]>
 
-export type BucketFieldpathInfer<
-    Def extends BucketModelDef<any, any>,
-    Prefix extends string = ''
-> = BucketFieldpathObjInfer<ReturnType<Def>, Prefix>
+export type BucketModelpathObjInfer<
+    Builders extends BucketModelFieldBuilders<any>
+> = UnionToIntersection<{
+    [K in keyof Builders]: {
+        [J in keyof Builders[K]['#modelpath'] as `.${K & string}${J & string}`]: Builders[K]['#modelpath'][J]
+    }
+}[keyof Builders]>
+
+export type BucketModelpathListInfer<
+    Builder extends AnyBucketModelFieldBuilder
+> = {
+    [J in keyof Builder['#modelpath'] as `.$${number}${J & string}`|`.${number}${J & string}`]: Builder['#modelpath'][J]
+} & {
+    [J in keyof Builder['#modelpath'] as `.${'*'}${J & string}`]: Builder['#modelpath'][J][]
+}
+
+export type BucketModelpathDictInfer<
+    Builder extends AnyBucketModelFieldBuilder
+> = {
+    [J in keyof Builder['#modelpath'] as `.$${number}${J & string}`|`.${string}${J & string}`]: Builder['#modelpath'][J]
+} & {
+    [J in keyof Builder['#modelpath'] as `.${'*'}${J & string}`]: Record<string, Builder['#modelpath'][J]>
+}
+
+export type BucketModelpathUnionInfer<
+    Builders extends AnyBucketModelFieldBuilder[]
+> = Builders[0]['#modelpath'] | Builders[1]['#modelpath']
+
+export type BucketModelpathInfer<
+    Def extends BucketModelDef<any, any>
+> = BucketModelpathRawInfer<ReturnType<Def>>
+
+
+/* Querypath */
+
+type BucketQuerypathRawInfer<
+    Builders extends BucketModelFieldBuilders<any>
+> = {
+    [K in keyof Builders]: {
+        [J in keyof Builders[K]['#querypath'] as `${K & string}${J & string}`]: Builders[K]['#querypath'][J]
+    }
+}[keyof Builders]
+
+export type BucketQuerypathObjInfer<
+    Builders extends BucketModelFieldBuilders<any>
+> = UnionToIntersection<{
+    [K in keyof Builders]: {
+        [J in keyof Builders[K]['#querypath'] as `.${K & string}${J & string}`]: Builders[K]['#querypath'][J]
+    }
+}[keyof Builders]>
+
+export type BucketQuerypathListInfer<
+    Builder extends AnyBucketModelFieldBuilder
+> = {
+    [J in keyof Builder['#querypath'] as `.${number|'#'|'*'}${J & string}`]: Builder['#querypath'][J]
+}
+
+export type BucketQuerypathDictInfer<
+    Builder extends AnyBucketModelFieldBuilder
+> = {
+    [J in keyof Builder['#querypath'] as `.${string|'#'|'*'}${J & string}`]: Builder['#querypath'][J]
+}
+
+export type BucketQuerypathInfer<
+    Def extends BucketModelDef<any, any>
+> = UnionToIntersection<BucketQuerypathRawInfer<ReturnType<Def>>>

--- a/src/elements/entities/bucket/model/bucket_model.schema.ts
+++ b/src/elements/entities/bucket/model/bucket_model.schema.ts
@@ -1,6 +1,6 @@
 import { $Dependency } from '~/engine/dependency';
 
-export type $BucketModelFieldType = 'boolean'|'date'|'datetime'|'duration'|'decimal'|'enum'|'file'|'float'|'int'|'string'|'obj'|'unknown'|'dict'
+export type $BucketModelFieldType = 'boolean'|'date'|'datetime'|'duration'|'decimal'|'enum'|'file'|'float'|'int'|'string'|'obj'|'unknown'|'dict'|'list'|'union'
 
 export type $BucketModelFieldCrypto = {
     algorithm: string,
@@ -19,7 +19,6 @@ export class $BucketModelField {
         public path: string,
         public type: $BucketModelFieldType,
         public alias: string,
-        public array: boolean,
         public required: boolean,
         public meta?: {
             enum?: {
@@ -37,7 +36,6 @@ export class $BucketModelField {
         },
         public defaultValue?: any,
         public children?: $BucketModelFields,
-        public or?: $BucketModelField,
         public crypto?: $BucketModelFieldCrypto
     ) {}
 
@@ -61,30 +59,74 @@ export class $BucketModel {
         public hasEncryptedField = false
     ) {}
 
-    public static get(
+    public static getField(
         model: $BucketModel,
-        fieldpath: string
-    ): $BucketModelField | undefined {
-        const paths = fieldpath.split('.')
+        modelpath: string
+    ): $BucketModelField[] {
+        const paths = modelpath.split('.')
 
-        let ref = model.fields as any;
-        for (let i = 0; i < paths.length; i++) {
-            const path = paths[i];
-            if (path === '#') {
-                continue;
+        const results: $BucketModelField[] = [];
+
+        let poll: {
+            i: number
+            field: $BucketModelField
+        }[] = [{ i: 0, field: { children: model.fields } as any }];
+
+        while (poll.length) {
+            
+            const next: {
+                i: number
+                field: $BucketModelField
+            }[] = [];
+
+            for (const item of poll) {
+                const path = paths[item.i];
+                if (!path) {
+                    results.push(item.field);
+                    continue;
+                }
+                
+                const field = item.field;
+
+                // If the field is a union, add all of it's children with the same path index
+                if (field.type === 'union') {
+                    next.push(...Object.values(field.children!).map(field => ({
+                        i: item.i,
+                        field
+                    })));
+                    continue;
+                }
+    
+                // If it's a list or dict, or an object 
+                if (field.type === 'list' || field.type === 'dict') {
+                    // If not, iterate
+                    next.push({
+                        i: item.i+1,
+                        field: field.children!['#']
+                    })
+                    continue;
+                }
+    
+                // If it's an object, walk it's children
+                if (field.type === 'obj' && path === '*') {
+                    next.push(...Object.values(field.children!).map(field => ({
+                        i: item.i+1,
+                        field
+                    })))
+                }
+                
+                const child = field.children![path];
+                if (child) {
+                    next.push({
+                        i: item.i+1,
+                        field: child
+                    })
+                }
             }
-            else {
-                ref = ref?.[path];
-            }
-            if (!ref?.children || i == paths.length-1) {
-                return ref;
-            }
-            if (!ref) {
-                return undefined;
-            }
-            ref = ref.children;
+            poll = next;
         }
-        return ref;
+
+        return results;
     }
 
     public static fieldsOfType(
@@ -109,6 +151,32 @@ export class $BucketModel {
         }
 
         return fields;
+    }
+
+    public static async forEachField(
+        template: $BucketModel,
+        predicate: (field: $BucketModelField, unionKey?: number) => Promise<void>
+    ) {
+        let poll: {
+            field: $BucketModelField,
+            unionKey?: number
+        }[] = Object.values(template.fields).map(field => ({ field }));
+        while (poll.length) {
+            const next: typeof poll = [];
+            for (const obj of poll) {
+                await predicate(obj.field, obj.unionKey);
+                
+                if (obj.field.children) {
+                    next.push(...Object.values(obj.field.children)
+                        .map((field, i) => ({
+                            field,
+                            unionKey: obj.field.type === 'union' ? i : undefined
+                        }))
+                    )
+                }
+            }
+            poll = next;
+        }
     }
 }
 

--- a/src/elements/entities/bucket/view/bucket_view.builder.ts
+++ b/src/elements/entities/bucket/view/bucket_view.builder.ts
@@ -23,7 +23,7 @@ export class BucketViewBuilder<
     
     public fields($: BucketViewDef<Space, Module, Bucket>) {
         const fieldBuilder = new BucketViewFieldFactory(this);
-        this._fields = $(fieldBuilder);
+        this._fields = $(fieldBuilder as never);
         return this;
     }
 
@@ -32,7 +32,7 @@ export class BucketViewBuilder<
     public static build(builder: BucketViewBuilder<any, any, any>, model: $BucketModel, graph: $BucketGraph, views: $BucketViews) {
         const fields = BucketViewFieldBuilder.buildFields(builder._fields, model, graph, views);
         const schema = new $BucketView(builder.name, fields);
-        schema.fields.id = new $BucketViewField('id', 'model', 'id', 'id', false, true, { model: { key: 'id' }});
+        schema.fields.id = new $BucketViewField('id', 'model', 'id', { model: { path: 'id' }});
         return schema;
     }
 

--- a/src/elements/entities/bucket/view/bucket_view.schema.ts
+++ b/src/elements/entities/bucket/view/bucket_view.schema.ts
@@ -1,4 +1,3 @@
-import { $BucketModelFieldType } from '../model/bucket_model.schema';
 import { $Bucket } from '../bucket.schema';
 import { AnyTrxNode } from '~/engine/transaction/trx_node';
 
@@ -9,11 +8,10 @@ export type $BucketViewFieldFn<
     ctx: { trx: TrxNode, raw: B['#data'], bucket: $Bucket }
 ) => any | Promise<any>
 
-export type $BucketViewFieldValue =
+export type $BucketViewFieldMeta =
 {
     model?: {
-        key: string,
-        enumOptions?: string | string[]
+        path: string
     }
     graph?: {
         link: string,
@@ -28,7 +26,6 @@ export type $BucketViewFieldValue =
     drive?: {
         path: string
     }
-    group?: {}
 }
 
 /**
@@ -41,12 +38,10 @@ export class $BucketViewField {
     constructor(
         public name: string,
         public scope: 'model'|'graph'|'computed'|'group'|'view'|'drive',
-        public type: $BucketModelFieldType | 'id',
         public alias: string,
-        public array: boolean | 'unknown',
-        public required: boolean,
-        public value: $BucketViewFieldValue,
-        public children?: $BucketViewFields
+        public meta: $BucketViewFieldMeta,
+        public children?: $BucketViewFields,
+        public chain?: $BucketViewField
     ) {}
 }
 

--- a/src/elements/entities/bucket/view/bucket_view.ts
+++ b/src/elements/entities/bucket/view/bucket_view.ts
@@ -1,10 +1,25 @@
 import { NesoiObj } from '~/engine/data/obj';
 import { Bucket } from '../bucket';
-import { $BucketView, $BucketViewField, $BucketViewFields } from './bucket_view.schema';
-import _Promise from '~/engine/util/promise';
+import { $BucketView, $BucketViewField } from './bucket_view.schema';
 import { AnyTrxNode } from '~/engine/transaction/trx_node';
-import { Tree } from '~/engine/data/tree';
+import _Promise from '~/engine/util/promise';
 import { NesoiError } from '~/engine/data/error';
+import { Tree } from '~/engine/data/tree';
+
+type ViewNode = {
+    field: $BucketViewField
+    data: {
+        value: Record<string, any>
+        index: (string|number)[]
+        target: Record<string, any>
+    }[]
+}
+type ViewLayer = ViewNode[]
+
+class ViewValue {
+    public value = undefined
+    constructor() {}
+}
 
 /**
  * @category Elements
@@ -20,115 +35,272 @@ export class BucketView<$ extends $BucketView> {
     public async parse<Obj extends NesoiObj>(
         trx: AnyTrxNode,
         raw: Obj
-    ): Promise<$['#data']> {
-        const bucket = this.bucket;
-        const doParse = async (schema: $BucketViewFields, index?: '*' | (string|number)[]) => {
-            const parsedObj = {} as any;
+    ): Promise<$['#data']> {  
 
-            // Model props
-            for (const k in schema) {
-                const prop = schema[k];
-                if (prop.scope !== 'model') { continue; }
-                parsedObj[k] = await parseModelProp(raw, prop, index);
-            }
-            
-            // Computed props
-            for (const k in schema) {
-                const prop = schema[k];
-                if (prop.$t !== 'bucket.view.field') { continue; }
-                if (prop.scope !== 'computed') { continue; }
-                const value = (prop as $BucketViewField).value.computed!;
-                parsedObj[k] = await _Promise.solve(
-                    value.fn({ trx, raw, bucket: bucket.schema })
-                );
-            }
-            
-            // Graph props
-            for (const k in schema) {
-                const prop = schema[k];
-                if (prop.$t !== 'bucket.view.field') { continue; }
-                if (prop.scope !== 'graph') { continue; }
-                const value = (prop as $BucketViewField).value.graph!;
-                let link;
-                if (!value.view) {
-                    link = bucket.graph.readLink(trx, raw, value.link, { silent: true }) // TODO: fieldpath indexes
-                }
-                else {
-                    link = bucket.graph.viewLink(trx, raw, value.link, value.view, { silent: true }) // TODO: fieldpath indexes
-                }
-                parsedObj[k] = await _Promise.solve(link);
-            }
-            
-            // Drive props
-            for (const k in schema) {
-                const prop = schema[k];
-                if (prop.$t !== 'bucket.view.field') { continue; }
-                if (prop.scope !== 'drive') { continue; }
-                if (!bucket.drive) {
-                    throw NesoiError.Bucket.Drive.NoAdapter({ bucket: bucket.schema.alias });
-                }
-                const value = (prop as $BucketViewField).value.drive!;
-                const model = Tree.get(raw, value.path);
-                if (Array.isArray(model)) {
-                    const public_urls: string[] = [];
-                    for (const obj of model) {
-                        public_urls.push(await bucket.drive.public(obj));
-                    }
-                    parsedObj[k] = public_urls;
-                }
-                else {
-                    parsedObj[k] = (await bucket.drive.public(model));
-                }
-            }
-            
-            // Group props
-            for (const k in schema) {
-                const prop = schema[k];
-                if (prop.$t !== 'bucket.view.field') { continue; }
-                if (prop.scope !== 'group') { continue; }
-                parsedObj[k] = await doParse(prop.children || {}, index); 
-            }
-            return parsedObj;
-        };
+        const parsed: Record<string, any> = {};
+        if ('__raw' in this.schema.fields) {
+            Object.assign(parsed, raw);
+        }
 
-        const parseModelProp = async (obj: Record<string, any>, prop: $BucketViewField, index?: '*' | (string|number)[], key?: string) => {
-            const value = prop.value.model!;
-            const rawValue = Tree.get(obj, key || value.key, index);
-
-            if (prop.children) {
-                if (prop.array) {
-                    if (!Array.isArray(rawValue)) {
-                        return undefined;
-                    }
-                    const parsedArray: any[] = []
-                    for (let i = 0; i < rawValue.length; i++) {
-                        const child = await doParse(prop.children, [...(index || []), i]);
-                        parsedArray.push(child)
-                    }
-                    return parsedArray;
-                }
-                else if (prop.type === 'dict') {
-                    if (typeof rawValue !== 'object' || Array.isArray(rawValue)) {
-                        return undefined;
-                    }
-                    const parsedDict: Record<string, any> = {}
-                    for (const j in rawValue) {
-                        parsedDict[j] = await parseModelProp(rawValue, prop.children.__dict, [...(index || []), j], j);
-                    }
-                    return parsedDict;
-                }
-                else {
-                    return doParse(prop.children, index || []);
-                }
-            }
-            return rawValue;        
-        };
+        let layer: ViewLayer = Object.values(this.schema.fields).map(field => ({
+            field,
+            data: [{
+                value: raw,
+                index: [],
+                target: parsed
+            }]
+        }))
         
-        const parsedObj = await doParse(this.schema.fields);
-        parsedObj['$v'] = this.schema.name;
+        while (layer.length) {
+            layer = await this.parseLayer(trx, raw, layer);
+        }
+
+        parsed['$v'] = this.schema.name;
         return {
             id: raw.id,
-            ...parsedObj
+            ...parsed
         };
+    }
+
+    private async parseLayer(trx: AnyTrxNode, raw: Record<string, any>, layer: ViewLayer) {
+        
+        const next: ViewLayer = [];
+
+        // Model props
+        for (const node of layer) {
+            if (node.field.scope !== 'model') continue;
+            next.push(...this.parseModelProp(raw, node));
+        }
+        // Computed props
+        for (const node of layer) {
+            if (node.field.scope !== 'computed') continue;
+            await this.parseComputedProp(trx, raw, node);
+        }
+        // Graph props
+        for (const node of layer) {
+            if (node.field.scope !== 'graph') continue;
+            await this.parseGraphProp(trx, raw, node);
+        }
+        // Drive props
+        for (const node of layer) {
+            if (node.field.scope !== 'drive') continue;
+            await this.parseDriveProp(trx, raw, node);
+        }
+        // Group props
+        for (const node of layer) {
+            if (node.field.scope !== 'group') continue;
+            if (!node.field.children) continue;
+            if ('__raw' in node.field.children) {
+                for (const d of node.data) {
+                    d.target[node.field.name] = d.value;
+                }
+            }
+            next.push(...Object.values(node.field.children).map(field => ({
+                field,
+                data: node.data
+            })))
+        }
+
+        // Chains
+        for (const node of layer) {
+            if (!node.field.chain) continue;
+            next.push({
+                field: node.field.chain,
+                data: node.data.map(d => ({
+                    index: d.index,
+                    target: d.target,
+                    value: d.target[node.field.name]
+                }))
+            })
+        }
+
+        return next;
+    }
+
+    /**
+     * [model]
+     * Read one property from 
+     */
+    private parseModelProp(raw: Record<string, any>, node: ViewNode) {
+        
+        const initAs = (!node.field.children) ? 'value' : 'obj';
+        const rawChild = '__raw' in (node.field.children || {})
+        const nextData = this.doParseModelProp(raw, node, initAs, rawChild);
+
+        if (!node.field.children) return [];
+
+        const next: ViewLayer = [];
+        for (const key in node.field.children) {
+            if (key === '__raw') continue;
+            next.push({
+                field: node.field.children![key],
+                data: nextData
+            })
+        }
+        return next;
+    }
+
+    private doParseModelProp(
+        raw: Record<string, any>,
+        node: ViewNode,
+        initAs: 'value'|'obj',
+        rawChild: boolean
+    ): ViewNode['data'] {
+        const modelpath = node.field.meta!.model!.path;
+        const paths = modelpath.split('.')
+        const name = node.field.name;
+
+        let poll: {
+            index: (string | number)[];
+            value: Record<string, any>;
+            target: Record<string, any>;
+            key: string | number;
+        }[] = node.data.map(d => ({
+            ...d,
+            value: raw,
+            key: name
+        }));
+
+        for (const path of paths) {
+            // *
+            if (path === '*') {
+                // Expand each value of the poll (assumed to be a dict or list)
+                poll = poll.map(item => {
+                    if (typeof item.value !== 'object') {
+                        throw new Error(`Failed to parse ${paths}, intermediate value ${item.value} is not a list or object`);
+                    }
+                    if (Array.isArray(item.value)) {
+                        item.target[item.key] = initAs === 'value'
+                            ? [...item.value]
+                            : item.value.map(() => ({}));
+
+                        return item.value.map((v, i) => ({
+                            index: [...item.index, i],
+                            value: v,
+                            target: item.target[item.key],
+                            key: i
+                        }))
+                    }
+                    else {
+                        item.target[item.key] = initAs === 'value'
+                            ? {...item.value}
+                            : Object.fromEntries(Object.entries(item.value).map(([k]) => [k,{}]));
+                            
+                        return Object.entries(item.value).map(([k, v]) => ({
+                            index: [...item.index, k],
+                            value: v,
+                            target: item.target[item.key],
+                            key: k
+                        }))
+                    }
+                }).flat(1);
+                continue;
+            }
+            // $1, $2.. or string|number
+            else {                
+                // Walk each node
+                const next: {
+                    index: (string|number)[]
+                    value: any
+                    target: Record<string, any>
+                    key: string | number
+                }[] = [];
+                for (const item of poll) {
+                    // $0, $1.. -> string
+                    const idx = path.match(/^\$(\d+)/)?.[1];
+                    let _path = path;
+                    if (idx !== undefined) {
+                        // Replace by index key
+                        _path = item.index[parseInt(idx)] as string;
+                    }
+                    
+                    const n = typeof item.value === 'object'
+                        ? item.value[_path]
+                        : undefined;
+                    item.target[item.key] = initAs === 'value'
+                        ? n
+                        : {};
+                    if (n !== undefined) {
+                        next.push({
+                            index: item.index,
+                            value: n,
+                            target: item.target,
+                            key: item.key
+                        });
+                    }
+                }
+                poll = next;
+            }
+        }
+
+        // For each leaf, if it's an object (not an array),
+        // pre-fill with it's value.
+        // This means that ...$.raw() only works on modelpaths that
+        // result in an object. Otherwise, it's ignored.
+        if (rawChild) {
+            for (const data of poll) {
+                if (typeof data.value === 'object' && !Array.isArray(data.value)) {
+                    data.target[data.key] = data.value;
+                }
+            }
+        }
+
+        return poll.map(p => ({
+            index: p.index,
+            value: p.value,
+            target: p.target[p.key]
+        }));
+    }
+
+    /**
+     * [computed]
+     */
+    private async parseComputedProp(trx: AnyTrxNode, raw: Record<string, any>, node: ViewNode) {
+        const meta = node.field.meta.computed!;
+        for (const entry of node.data) {
+            entry.target[node.field.name] = await _Promise.solve(
+                meta.fn({ trx, raw, bucket: this.bucket.schema })
+            );
+        }
+    }
+
+    /**
+     * [graph]
+     */
+    private async parseGraphProp(trx: AnyTrxNode, raw: Record<string, any>, node: ViewNode) {
+        const meta = node.field.meta.graph!;
+        for (const entry of node.data) {
+            let link;
+            if (!meta.view) {
+                link = this.bucket.graph.readLink(trx, raw, meta.link, { silent: true })
+            }
+            else {
+                link = this.bucket.graph.viewLink(trx, raw, meta.link, meta.view, { silent: true })
+            }
+            entry.target[node.field.name] = await _Promise.solve(link);
+        }
+    }
+
+    /**
+     * [drive]
+     */
+    private async parseDriveProp(trx: AnyTrxNode, raw: Record<string, any>, node: ViewNode) {
+        if (!this.bucket.drive) {
+            throw NesoiError.Bucket.Drive.NoAdapter({ bucket: this.bucket.schema.alias });
+        }
+        const meta = node.field.meta.drive!;
+        for (const entry of node.data) {
+            const value = Tree.get(raw, meta.path);
+            if (Array.isArray(value)) {
+                const public_urls: string[] = [];
+                for (const obj of value) {
+                    public_urls.push(await this.bucket.drive.public(obj));
+                }
+                entry.target[node.field.name] = public_urls;
+            }
+            else {
+                entry.target[node.field.name] = await this.bucket.drive.public(value);
+            }
+        }
     }
 }

--- a/src/elements/entities/message/message.infer.ts
+++ b/src/elements/entities/message/message.infer.ts
@@ -4,53 +4,31 @@ import { $Module } from '~/schema';
 import { $Message } from './message.schema';
 
 export type $MessageInputInfer<
-    Builder,
-    Fields extends Record<string, { path: any, data: any, opt: any , nul: any }> = {
-        [K in keyof Builder]:
-            Builder[K] extends MessageTemplateFieldBuilder<any, any, infer I, any, any, infer Opt, infer Nul>
-                ? {
-                    path: `${K & string}${keyof I & string}`,
-                    data: I[keyof I],
-                    opt: Opt[0],
-                    nul: Nul[0]
-                }
-                : never
-    }
+    Fields extends MessageTemplateFieldBuilders
 > = {
     // Required fields
     [K in keyof Fields as 
-        Fields[K]['opt'] extends never ? Fields[K]['path'] : never
-    ]: Fields[K]['data'] | Fields[K]['nul']
+        Fields[K]['#optional'][0] extends true ? never : `${K & string}${Fields[K]['#input_suffix']}`
+    ]: Fields[K]['#input']
 } & {
     // Optional fields
     [K in keyof Fields as 
-        Fields[K]['opt'] extends never ? never : Fields[K]['path']
-    ]?: Fields[K]['data'] | Fields[K]['nul']
+        Fields[K]['#optional'][0] extends true ? `${K & string}${Fields[K]['#input_suffix']}` : never
+    ]?: Fields[K]['#input']
 }
 
 export type $MessageOutputInfer<
-    Builder,
-    Fields extends Record<string, { path: any, data: any, opt: any , nul: any }> = {
-        [K in keyof Builder]:
-            Builder[K] extends MessageTemplateFieldBuilder<any, any, any, infer O, any, infer Opt, infer Nul>
-                ? {
-                    path: `${K & string}${keyof O & string}`,
-                    data: O[keyof O],
-                    opt: Opt[1],
-                    nul: Nul[1]
-                }
-                : never
-    }
+    Fields extends MessageTemplateFieldBuilders
 > = {
     // Required fields
     [K in keyof Fields as 
-        Fields[K]['opt'] extends never ? Fields[K]['path'] : never
-    ]: Fields[K]['data'] | Fields[K]['nul']
+        Fields[K]['#optional'][1] extends true ? never : K
+    ]: Fields[K]['#output']
 } & {
     // Optional fields
     [K in keyof Fields as 
-        Fields[K]['opt'] extends never ? never : Fields[K]['path']
-    ]?: Fields[K]['data'] | Fields[K]['nul']
+        Fields[K]['#optional'][1] extends true ? K : never
+    ]?: Fields[K]['#output']
 }
 
 export interface $MessageInfer<

--- a/src/elements/entities/message/message.schema.ts
+++ b/src/elements/entities/message/message.schema.ts
@@ -30,7 +30,7 @@ export class $Message {
                 if (field.type === 'id') {
                     str += `(${field.meta.id!.bucket.refName})`;
                 }
-                if (field.type === 'enum') {
+                else if (field.type === 'enum') {
                     const options = field.meta.enum!.options
                     if (typeof options === 'object') {
                         str += `(${Object.keys(options)})`;
@@ -39,7 +39,7 @@ export class $Message {
                         str += `(${options})`;
                     }
                 }
-                if (field.array) {
+                else if (field.type === 'list') {
                     str += '[]';
                 }
                 str += '\n';

--- a/src/elements/entities/message/template/message_template.builder.ts
+++ b/src/elements/entities/message/template/message_template.builder.ts
@@ -22,7 +22,7 @@ export class MessageTemplateBuilder {
     /// Build
     
     public static build(builder: MessageTemplateBuilder, tree: ModuleTree, module: $Module) {
-        const fields = MessageTemplateFieldBuilder.buildChildren(builder._fields, tree, module);
+        const fields = MessageTemplateFieldBuilder.buildMany(builder._fields, tree, module);
         return new $MessageTemplate(
             fields
         );

--- a/src/elements/entities/message/template/message_template_field.builder.ts
+++ b/src/elements/entities/message/template/message_template_field.builder.ts
@@ -5,7 +5,6 @@ import { NesoiDate } from '~/engine/data/date';
 import { NesoiError } from '~/engine/data/error';
 import { $Message } from '../message.schema';
 import { ModuleTree } from '~/engine/tree';
-import { NesoiObj } from '~/engine/data/obj';
 import { $Dependency, $Tag } from '~/engine/dependency';
 import { MessageEnumpath } from '../../constants/constants.schema';
 import { NesoiDecimal } from '~/engine/data/decimal';
@@ -32,10 +31,6 @@ export class MessageTemplateFieldFactory<
 
     /**
      * Specifies an alias for the field.
-     * - If this field is a union (.or), this alias is used when
-     * referring to the union and it's first option.
-     * - You can specify a different alias for the first options
-     * by also using the .as() after the type
     */
     as(alias: string) {
         const chain = new MessageTemplateFieldFactory(this.module);
@@ -44,7 +39,7 @@ export class MessageTemplateFieldFactory<
     }
 
     get any() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': any }, { '': any }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, any, any, {}>(
             'unknown',
             {},
             this.alias
@@ -52,7 +47,7 @@ export class MessageTemplateFieldFactory<
     }
 
     ts<T = any>() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': T }, { '': T }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, T, T, {}>(
             'unknown',
             {},
             this.alias
@@ -60,7 +55,7 @@ export class MessageTemplateFieldFactory<
     }
 
     get boolean() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': boolean }, { '': boolean }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, boolean, boolean, {}>(
             'boolean',
             {},
             this.alias
@@ -68,7 +63,7 @@ export class MessageTemplateFieldFactory<
     }
     
     get date() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string }, { '': NesoiDate }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string, NesoiDate, {}>(
             'date',
             {},
             this.alias
@@ -76,7 +71,7 @@ export class MessageTemplateFieldFactory<
     }
      
     get datetime() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string }, { '': NesoiDatetime }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string, NesoiDatetime, {}>(
             'datetime',
             {},
             this.alias
@@ -84,7 +79,7 @@ export class MessageTemplateFieldFactory<
     }
      
     get duration() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string }, { '': NesoiDuration }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string, NesoiDuration, {}>(
             'duration',
             {},
             this.alias
@@ -92,7 +87,7 @@ export class MessageTemplateFieldFactory<
     }
      
     decimal(config?: $MessageTemplateFieldMeta['decimal']) {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string }, { '': NesoiDecimal }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string, NesoiDecimal, {}>(
             'decimal',
             { decimal: config },
             this.alias
@@ -121,7 +116,7 @@ export class MessageTemplateFieldFactory<
             }
         }
 
-        return new MessageTemplateFieldBuilder<Module, Message, { '': Opt & string }, { '': Opt & string }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, Opt & string, Opt & string, {}>(
             'enum',
             { enum: { options, dep } },
             this.alias,
@@ -130,7 +125,7 @@ export class MessageTemplateFieldFactory<
     }
     
     file(config?: $MessageTemplateFieldMeta['file']) {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': NesoiFile }, { '': NesoiFile }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, NesoiFile, NesoiFile, {}>(
             'file',
             { file: config },
             this.alias
@@ -138,7 +133,7 @@ export class MessageTemplateFieldFactory<
     }
     
     get float() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': number }, { '': number }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, number, number, {}>(
             'float',
             {},
             this.alias
@@ -151,23 +146,26 @@ export class MessageTemplateFieldFactory<
     >(bucket: Name, view?: View) {
         // Module and tag are updated on build
         const ref = new $Dependency(this.module, 'bucket', bucket as string);
-        return new MessageTemplateFieldBuilder<Module, Message, {
-            '_id': (Module['buckets'][Name]['#data'] & NesoiObj)['id']
-                }, 
-        {
-            '': undefined extends View
+        return new MessageTemplateFieldBuilder<
+            Module,
+            Message,
+            Module['buckets'][Name]['#data']['id'], 
+            undefined extends View
                 ? Module['buckets'][Name]['#data']
                 : Module['buckets'][Name]['views'][NonNullable<View>]['#data'],
-        }, {}>(
-                'id',
-                { id: { bucket: ref, view: view as string } },
-                this.alias,
-                undefined
-                );
+            {},
+            [false,false],
+            '_id'
+        >(
+            'id',
+            { id: { bucket: ref, view: view as string } },
+            this.alias,
+            undefined
+        );
     }
     
     get int() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': number }, { '': number }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, number, number, {}>(
             'int',
             {},
             this.alias
@@ -175,7 +173,7 @@ export class MessageTemplateFieldFactory<
     }
 
     get string() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string }, { '': string }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string, string, {}>(
             'string',
             {},
             this.alias
@@ -183,7 +181,7 @@ export class MessageTemplateFieldFactory<
     }
 
     get string_or_number() {
-        return new MessageTemplateFieldBuilder<Module, Message, { '': string|number }, { '': string|number }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, string|number, string|number, {}>(
             'string_or_number',
             {},
             this.alias
@@ -195,7 +193,7 @@ export class MessageTemplateFieldFactory<
     >(children: Builders) {
         type I = $MessageInputInfer<Builders>
         type O = $MessageOutputInfer<Builders>
-        return new MessageTemplateFieldBuilder<Module, Message, { '': I }, { '': O }, Builders>(
+        return new MessageTemplateFieldBuilder<Module, Message, I, O, Builders>(
             'obj',
             {},
             this.alias,
@@ -203,15 +201,10 @@ export class MessageTemplateFieldFactory<
         );
     }
     
-    dict<Builder extends MessageTemplateFieldBuilder<Module, Message, any, any, any>>(item: Builder) {
-        type I = Builder extends MessageTemplateFieldBuilder<any, any, infer X, any, any>
-            ? X[keyof X]
-            : never
-        type O = Builder extends MessageTemplateFieldBuilder<any, any, any, infer X, any>
-            ? X[keyof X]
-            : never
-        item = item.optional as any;
-        return new MessageTemplateFieldBuilder<Module, Message, { '': Record<string, I>}, { '': Record<string, O> }, { __dict: Builder }>(
+    dict<Builder extends MessageTemplateFieldBuilder<Module, Message, any, any, any, any, any>>(item: Builder) {
+        type I = Builder['#input']
+        type O = Builder['#output']
+        return new MessageTemplateFieldBuilder<Module, Message, Record<string, I>, Record<string, O>, { __dict: Builder }>(
             'dict',
             {},
             this.alias,
@@ -219,17 +212,41 @@ export class MessageTemplateFieldFactory<
         );
     }
     
+    list<Builder extends MessageTemplateFieldBuilder<Module, Message, any, any, any, any, any>>(item: Builder) {
+        type I = Builder['#input']
+        type O = Builder['#output']
+        return new MessageTemplateFieldBuilder<Module, Message, I[], O[], { '#': Builder }>(
+            'list',
+            {},
+            this.alias,
+            { '#': item }
+        );
+    }
+    
+    union<
+        Builders extends AnyMessageTemplateFieldBuilder[],
+    >(...children: Builders) {
+        type I = Builders[number]['#input']
+        type O = Builders[number]['#output']
+        return new MessageTemplateFieldBuilder<Module, Message, I, O, { [x: number]: Builders[number] }>(
+            'union',
+            {},
+            this.alias,
+            Object.fromEntries(children.map((c,i) => [i,c])) as never
+        );
+    }
+
     msg<
         MessageName extends keyof Module['messages'],
         Message extends Module['messages'][MessageName],
         Builders extends MessageTemplateFieldBuilders
-    >(msg: MessageName, extra: Builders) {
+    >(msg: MessageName, extra: Builders = {} as never) {
         // Module and tag are updated on build
         const ref = new $Dependency(this.module, 'message', msg as string);
         type Infer = $MessageInfer<any, any, Builders>
         type I = Omit<Message['#raw'], '$'> & Infer['#raw']
         type O = Omit<Message['#parsed'], '$'> & Infer['#parsed']
-        return new MessageTemplateFieldBuilder<Module, Message, { '': I }, { '': O }, {}>(
+        return new MessageTemplateFieldBuilder<Module, Message, I, O, {}>(
             'msg',
             { msg: ref },
             this.alias,
@@ -260,136 +277,77 @@ export class MessageTemplateFieldFactory<
 export class MessageTemplateFieldBuilder<
     Module extends $Module,
     Message extends $Message,
-    DefinedInput,
-    DefinedOutput,
+    Input,
+    Output,
     Children extends MessageTemplateFieldBuilders,
-    Optional extends [undefined|never, undefined|never] = [never, never], // Used to infer the message type
-    Nullable extends [null|never, null|never] = [never, never], // Used to infer the message type
+    Optional = [false, false],
+    InputSuffix extends string = ''
 > {
+    public '#input': Input
+    public '#input_suffix': InputSuffix
+    public '#output': Output
+    public '#optional': Optional
 
-    private _array = false;
     private _required = true;
     private _defaultValue?: any = undefined;
-    private _nullable = true;
+    private _nullable = false;
     private _rules: $MessageTemplateRule[] = [];
-    private _arrayRules: $MessageTemplateRule[] = [];
-    private _or?: AnyMessageTemplateFieldBuilder
-    private preAlias?: string
 
     constructor(
         private type: $MessageTemplateFieldType,
         private value: $MessageTemplateFieldMeta,
         private alias?: string,
         private children?: Children
-    ) {
-        this.preAlias = alias;
-    }
+    ) {}
 
     as(alias: string) {
         this.alias = alias;
         return this;
     }
 
-    get optional() {
+    get optional(): MessageTemplateFieldBuilder<
+        Module,
+        Message,    
+        Input | undefined,
+        Output | undefined,
+        Children,
+        [true, true],
+        InputSuffix
+        > {
         this._required = false;
-        if (this._or) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            this._or.optional
-        }
-        return this as MessageTemplateFieldBuilder<
-            Module,
-            Message,    
-            DefinedInput,
-            DefinedOutput,
-            Children,
-            /* Optional */ [undefined, undefined],
-            Nullable
-        >;
+        return this as never;
     }
 
-    default(value: DefinedInput[keyof DefinedInput] | Nullable[0]) {
+    default(value: Output): MessageTemplateFieldBuilder<
+        Module,
+        Message,    
+        Input | undefined,
+        Output,
+        Children,
+        [true, (Optional & [boolean, boolean])[1]],
+        InputSuffix
+    > {
         this._required = false;
         this._defaultValue = value;
-        if (this._or) {
-            this._or.default(value);
-        }
-        return this as MessageTemplateFieldBuilder<
-            Module,
-            Message,    
-            DefinedInput,
-            DefinedOutput,
-            Children,
-            /* Optional */ [undefined, never],
-            Nullable
-        >;
+        return this as never;
     }
     
-    get nullable() {
+    get nullable(): MessageTemplateFieldBuilder<
+        Module,
+        Message,    
+        Input | null,
+        Output | null,
+        Children,
+        Optional,
+        InputSuffix
+        > {
         this._nullable = true;
-        if (this._or) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            this._or.nullable;
-        }
-        return this as MessageTemplateFieldBuilder<
-            Module,
-            Message,    
-            DefinedInput,
-            DefinedOutput,
-            Children,
-            Optional,
-            /* Nullable */ [null, null]
-        >;
+        return this as never;
     }
 
-    rule(rule: MessageTemplateRuleDef<DefinedOutput[keyof DefinedOutput], Message['#raw']>) {
-        if (this._array) {
-            this._arrayRules.push(rule as any);
-        }
-        else {
-            this._rules.push(rule as any);
-        }
+    rule(rule: MessageTemplateRuleDef<Output, Message['#raw']>) {
+        this._rules.push(rule as any);
         return this;
-    }
-
-    get array() {
-        this._array = true;
-        if (this._or) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            this._or.array;
-        }
-        return this as any as MessageTemplateFieldBuilder<
-            Module,
-            Message,    
-            /* DefinedInput */ { [K in keyof DefinedInput]: DefinedInput[K][] },
-            /* DefinedOutput */ { [K in keyof DefinedOutput]: DefinedOutput[K][] },
-            Children,
-            Optional,
-            Nullable
-        >;
-    }
-
-    or<
-        Def extends AnyMessageTemplateFieldBuilder
-    >(def: Def) {
-        this._or = def;
-        this._or.preAlias = this.preAlias;
-        this._or._array = this._array;
-        this._or._defaultValue = this._defaultValue;
-        this._or._nullable = this._nullable;
-        this._or._required = this._required;
-        this._or._arrayRules = this._arrayRules;
-        
-        type I = Def extends MessageTemplateFieldBuilder<any, any, infer X, any, any> ? X : never;
-        type O = Def extends MessageTemplateFieldBuilder<any, any, any, infer X, any> ? X : never;
-        return this as any as MessageTemplateFieldBuilder<
-            Module,
-            Message,    
-            /* DefinedInput */ { [K in keyof DefinedInput]: DefinedInput[K] | I[keyof I] },
-            /* DefinedOutput */ { [K in keyof DefinedOutput]: DefinedOutput[K] | O[keyof O] },
-            Children,
-            Optional,
-            Nullable
-        >;
     }
 
     // Build
@@ -401,85 +359,105 @@ export class MessageTemplateFieldBuilder<
         module: $Module,
         basePathRaw: string,
         basePathParsed: string
-    ) {
-        const or: any = builder._or
-            ? this.build(builder._or, name, tree, module, basePathRaw, basePathParsed)
-            : undefined;
-
-        const pathParsed = basePathParsed + name;
-        const pathRaw = basePathParsed + (
-            builder.type === 'id'
-                ? builder._array ? `${name}_ids` : `${name}_id`
-                : name
+    ) {      
+        const pathRaw = basePathRaw + (
+            builder.type === 'id' ? `${name}_id` : name
         );
-        const childrenBasePathRaw = pathRaw + (builder._array ? '.#.' : '.');
-        const childrenBasePathParsed = pathParsed + (builder._array ? '.#.' : '.');
+        const pathParsed = basePathParsed + name;
 
-        if (builder.value.id) {
-            const bucket = tree.getSchema(builder.value.id.bucket) as $Bucket;
-            builder.value.id.type = bucket.model.fields.id.type as 'int'|'string';
+        const childrenBasePathRaw = pathRaw + '.';
+        const childrenBasePathParsed = pathParsed + '.';
+
+        let type = builder.type;
+        let children;
+
+        if (builder.type === 'id') {
+            const bucket = tree.getSchema(builder.value.id!.bucket) as $Bucket;
+            builder.value.id!.type = bucket.model.fields.id.type as 'int'|'string';
+        }
+        // A .msg() parameter is an obj which takes fields from
+        // another message
+        else if (builder.type === 'msg') {
+            const dep = builder.value.msg!;
+            if (dep.type !== 'message') {
+                throw NesoiError.Builder.Message.UnknownModuleMessage(dep.tag);
+            }
+            const $msg = tree.getSchema(dep) as $Message | undefined;
+            if (!$msg) {
+                throw NesoiError.Builder.Message.UnknownModuleMessage(dep.tag);
+            }
+            if (dep.module !== module.name) {
+                if (!(dep.refName in module.externals.messages)) {
+                    throw NesoiError.Builder.Message.UnknownModuleMessage(dep.tag);
+                }
+            }
+            
+            const injectFields = (target: $MessageTemplateFields, fields: $MessageTemplateFields) => {
+                for (const key in fields) {
+                    target[key] = $MessageTemplateField.clone(fields[key]);
+                    target[key].pathRaw = childrenBasePathRaw + target[key].pathRaw;
+                    target[key].pathParsed = childrenBasePathParsed + target[key].pathParsed;
+                    if (fields[key].children) {
+                        target[key].children = {};
+                        injectFields(target[key].children!, fields[key].children!);
+                    }
+                }
+            }
+            
+            type = 'obj';
+            children = {};
+            injectFields(children, $msg.template.fields);
+        }
+        else if (builder.type === 'list') {
+            children = MessageTemplateFieldBuilder.buildMany( builder.children, tree, module, childrenBasePathRaw, childrenBasePathParsed, '#', '#');
+        }
+        else if (builder.type === 'dict') {
+            children = MessageTemplateFieldBuilder.buildMany( builder.children, tree, module, childrenBasePathRaw, childrenBasePathParsed, '#', '#');
+        }
+        else if (builder.type === 'union') {
+            children = MessageTemplateFieldBuilder.buildMany( builder.children, tree, module, basePathRaw, basePathParsed, name, undefined);
+        }
+        // All other fields build their children directly
+        else if (builder.children) {
+            children = MessageTemplateFieldBuilder.buildMany( builder.children, tree, module, childrenBasePathRaw, childrenBasePathParsed);
         }
 
         return new $MessageTemplateField(
-            builder.type,
+            type,
             name,
             builder.alias || name,
-            builder.preAlias || name,
             pathRaw,
             pathParsed,
-            builder._array,
             builder._required,
             builder._defaultValue,
             builder._nullable,
             builder._rules,
-            builder._arrayRules,
             builder.value,
-            builder.children ? MessageTemplateFieldBuilder.buildChildren( builder.children, tree, module, childrenBasePathRaw, childrenBasePathParsed) : undefined,
-            or
+            children
         );
     }
 
-    public static buildChildren(
+    public static buildMany(
         fields: MessageTemplateFieldBuilders,
         tree: ModuleTree,
         module: $Module,
         basePathRaw: string = '',
-        basePathParsed: string = ''
+        basePathParsed: string = '',
+        name?: string,
+        key?: string,
     ) {
         const schema = {} as $MessageTemplateFields;
+
         for (const c in fields) {
+            if (c === '__ext') continue;
             const child = fields[c];
+            schema[key||c] = MessageTemplateFieldBuilder.build(child, name||c, tree, module, basePathRaw, basePathParsed);
+        }
 
-            // Extended fields inherit from other messages
-            if ((child as any).__ext) {
-                const ext = tree.getSchema((child as any).__ext as unknown as $Dependency) as $Message;
-                schema[c].children = Object.assign({}, ext.template.fields, schema[c].children || {});
-                continue;
-            }
-            const param = c;
-            // A .msg() parameter is an obj which takes fields from
-            // another message
-            if (child.type === 'msg') {
-                const name = child.value.msg!.name;
-                const $msg = module.messages[name];
-                if (!$msg) {
-                    throw NesoiError.Builder.Message.UnknownModuleMessage(name);
-                }
-
-                const builder = new MessageTemplateFieldFactory(module.name).obj({});
-                builder.alias = child.alias;
-                builder._required = child._required;
-                builder._defaultValue = child._defaultValue;
-                builder._nullable = child._nullable;
-                builder._rules = child._rules.slice(0,-1);
-                builder.children = child.children;
-                schema[param] = MessageTemplateFieldBuilder.build(builder, c, tree, module, basePathRaw, basePathParsed);
-                schema[param].children = schema[param].children || {};
-                Object.assign(schema[param].children!, $msg.template.fields);
-                continue;
-            }
-            // All other parameters are built directly
-            schema[param] = MessageTemplateFieldBuilder.build(child, c, tree, module, basePathRaw, basePathParsed);
+        // Extended field groups inherit from other messages
+        if ('__ext' in fields) {
+            const ext = tree.getSchema(fields.__ext as unknown as $Dependency) as $Message;
+            Object.assign(schema, ext.template.fields);
         }
         return schema;
     }
@@ -489,7 +467,7 @@ export type MessageTemplateFieldBuilders = {
     [x: string]: AnyMessageTemplateFieldBuilder
 }
 
-export type AnyMessageTemplateFieldBuilder = MessageTemplateFieldBuilder<any, any, any, any, any>
+export type AnyMessageTemplateFieldBuilder = MessageTemplateFieldBuilder<any, any, any, any, any, any, any>
 
 // Generic version of $MessageTemplateRule
 export type MessageTemplateRuleDef<I,Msg> = (def: {

--- a/src/elements/entities/message/template/message_template_parser.ts
+++ b/src/elements/entities/message/template/message_template_parser.ts
@@ -1,4 +1,4 @@
-import { parseDict, parseBoolean, parseDate, parseDatetime, parseEnum, parseFile, parseFloat_, parseId, parseInt_, parseObj, parseString, parseStringOrNumber, parseDecimal, parseDuration } from '~/engine/util/parse';
+import { parseDict, parseBoolean, parseDate, parseDatetime, parseEnum, parseFile, parseFloat_, parseId, parseInt_, parseObj, parseString, parseStringOrNumber, parseDecimal, parseDuration, parseList } from '~/engine/util/parse';
 import { $MessageTemplateField, $MessageTemplateFields } from './message_template.schema';
 import { NesoiError } from '~/engine/data/error';
 import { AnyTrxNode } from '~/engine/transaction/trx_node';
@@ -6,7 +6,6 @@ import { AnyTrxNode } from '~/engine/transaction/trx_node';
 // TODO: OPTIMIZATION
 // Parse everything that's static first, then move on to
 // parsing ids etc.
-
 
 export async function MessageTemplateFieldParser(
     trx: AnyTrxNode,
@@ -17,8 +16,8 @@ export async function MessageTemplateFieldParser(
     const inject = {} as Record<string, any>;
     for (const k in fields) {
         const field = fields[k];
-        const key_raw = field.path_raw.split('.')[0];
-        const key_parsed = field.path_parsed.split('.')[0];
+        const key_raw = field.pathRaw.split('.')[0];
+        const key_parsed = field.pathParsed.split('.')[0];
         
         const value = raw[key_raw as never];
         parsed[key_parsed as never] = await parseFieldValue(trx, field, [field.name], raw, value, inject);
@@ -56,22 +55,8 @@ async function parseFieldValue(
         }
     }
 
-    let output;
-    if (field.array) {
-        if (!Array.isArray(value)) {
-            throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'list' });
-        }
-        output = [];
-        for (let i = 0; i < value.length; i++) {
-            const v = value[i];
-            const parsedValue = await _attemptUnion(trx, field, [...path, i.toString()], raw, v, inject);
-            output.push(parsedValue);
-        }
-        output = await applyFieldRules('array', field, path, raw, output, inject);
-    }
-    else {
-        output = await _attemptUnion(trx, field, path, raw, value, inject);
-    }
+    let output = await _attemptUnion(trx, field, path, raw, value, inject);
+    output = await applyFieldRules(field, path, raw, output, inject);
 
     return output;
 }
@@ -89,38 +74,36 @@ async function _attemptUnion(
     path: string[],
     raw: Record<string, any>,
     value: any,
-    inject: Record<string, any>,
-    unionErrors: any[] = []
+    inject: Record<string, any>
 ): Promise<any> {
-    let output: any = undefined;
-    try {
-        output = await _runParseMethod(trx, field, path, raw, value, inject)
+    if (field.type !== 'union') {
+        return _runParseMethod(trx, field, path, raw, value, inject)
     }
-    catch(e) {
-        const ue = [
-            ...unionErrors,
-            {
-                option: field.alias,
-                name: (e as any).name,
-                status: (e as any).status,
-                message: (e as any).message,
-                data: (e as any).data,
-            }
-        ]
 
-        // If failed and there's a second option, atempt it
-        if (field.or) {
-            return await _attemptUnion(trx, field.or, path, raw, value, inject, ue);
+    const unionErrors: any[] = [];
+    let output: any = undefined;
+    for (const k in field.children) {
+        const option = field.children[k];
+        try {
+            output = await _runParseMethod(trx, option, path, raw, value, inject)
+            break;
         }
-        // If this error was not the first attempt, and we have no other option
-        // we throw a specific error
-        // This avoid confusion for the client when parsing unions
-        if (unionErrors.length) {
-            throw NesoiError.Message.ValueDoesntMatchUnion({ alias: field.preAlias, path: path.join('.'), value, unionErrors: ue });
+        catch(e) {
+            unionErrors.push(
+                {
+                    option: option.alias,
+                    name: (e as any).name,
+                    status: (e as any).status,
+                    message: (e as any).message,
+                    data: (e as any).data,
+                }
+            )
         }
-        throw e;
     }
-    output = await applyFieldRules('item', field, path, raw, output, inject);
+    if (unionErrors.length === Object.keys(field.children!).length) {
+        throw NesoiError.Message.ValueDoesntMatchUnion({ alias: field.alias, path: path.join('.'), value, unionErrors });
+    }
+
     return output;
 }
 
@@ -141,7 +124,8 @@ async function _runParseMethod(
     switch (field.type) {
     case 'obj':
     case 'dict':
-        return await parseParentField(trx, field, path, raw, value, inject);
+    case 'list':
+        return parseParentField(trx, field, path, raw, value, inject);
     case 'unknown':
         return value;
     case 'boolean':
@@ -167,7 +151,7 @@ async function _runParseMethod(
     case 'string_or_number':
         return parseStringOrNumber(field, path, value)
     case 'id':
-        return await parseIdField(trx, field, path, value)
+        return parseIdField(trx, field, path, value)
     }
 
     throw NesoiError.Builder.Message.UnknownTemplateFieldType(field.type);
@@ -175,7 +159,7 @@ async function _runParseMethod(
 }
 
 /**
- * [Parser Step 3-b]: 'obj' or 'dict'
+ * [Parser Step 3-b]: 'obj' or 'dict' or 'list'
  * 
  * - The parser methods only return a tuple of field and value, to be parsed again by (step 1)
  * - When calling step 1, the child property name is appended to the path
@@ -189,20 +173,31 @@ async function parseParentField(
     inject: Record<string, any>
 ): Promise<any> {
 
-    let children;
-    if (field.type === 'obj') {
-        children = parseObj(field, path, value)
+    if (field.type === 'list') {
+        const children = parseList(field, path, value)
+        const parsedParent: any[] = [];
+        for (const key in children) {
+            const child = children[key];
+            parsedParent.push(await parseFieldValue(trx, child.field, [...path, key], raw, child.value, inject));
+        }
+        return parsedParent;
     }
     else {
-        children = parseDict(field, path, value)
-    }
-
-    const parsedParent: Record<string, any> = {};
-    for (const key in children) {
-        const child = children[key];
-        parsedParent[key] = await parseFieldValue(trx, child.field, [...path, key], raw, child.value, inject);
-    }
-    return parsedParent;
+        
+        let children;
+        if (field.type === 'obj') {
+            children = parseObj(field, path, value)
+        }
+        else {
+            children = parseDict(field, path, value)
+        }
+        const parsedParent: Record<string, any> = {};
+        for (const key in children) {
+            const child = children[key];
+            parsedParent[key] = await parseFieldValue(trx, child.field, [...path, key], raw, child.value, inject);
+        }
+        return parsedParent;
+    }    
 }
 
 /**
@@ -220,12 +215,7 @@ async function parseIdField(
     const type = field.meta.id!.type;
     const view = field.meta.id!.view;
     const parsed = await parseId(field, path, value, trx, bucket.refName, type, view) as any;
-    if (field.array) {
-        return parsed.map((p: any) => p.obj)
-    }
-    else {
-        return parsed.obj
-    }   
+    return parsed.obj
 }
 
 
@@ -263,7 +253,6 @@ export function isEmpty(value: any) {
  */
 
 async function applyFieldRules(
-    mode: 'item'|'array',
     field: $MessageTemplateField,
     path: string[],
     raw: Record<string, any>,
@@ -271,12 +260,7 @@ async function applyFieldRules(
     inject: Record<string, any>
 ): Promise<any> {
     let output = value;
-
-    // If mode is item, the value received is not an array
-    //  - This comes from a .rule *before* .array
-    // If mode is array, the value received is an array
-    //  - This comes from a .rule *after* .array
-    const rules = mode === 'item' ? field.rules : field.arrayRules;
+    const rules = field.rules;
 
     for (const r in rules) {
         const rule = rules[r];

--- a/src/engine/apps/inline.app.ts
+++ b/src/engine/apps/inline.app.ts
@@ -158,6 +158,7 @@ export class InlineApp<
         Object.values(modules).forEach(module => {
             module.injectDependencies(modules, {
                 buckets: Object.values(module.schema.externals.buckets),
+                messages: Object.values(module.schema.externals.messages),
                 jobs: Object.values(module.schema.externals.jobs),
                 machines: Object.values(module.schema.externals.machines),
             })

--- a/src/engine/data/trash.ts
+++ b/src/engine/data/trash.ts
@@ -22,14 +22,14 @@ export const $TrashBucket = new $Bucket(
     'trash',
     'Trash',
     new $BucketModel({
-        id: new $BucketModelField('id','id','int','id',false,true),
-        module: new $BucketModelField('module','module','string','Module Name',false,true),
-        bucket: new $BucketModelField('bucket','bucket','string','Bucket Name',false,true),
-        object_id: new $BucketModelField('object_id','object_id','int','Object ID',false,true),
-        object: new $BucketModelField('object','object','dict','Object',false,true,undefined,undefined,{
-            __dict: new $BucketModelField('','','unknown','',false,true,undefined,undefined)
+        id: new $BucketModelField('id','id','int','id',true),
+        module: new $BucketModelField('module','module','string','Module Name',true),
+        bucket: new $BucketModelField('bucket','bucket','string','Bucket Name',true),
+        object_id: new $BucketModelField('object_id','object_id','int','Object ID',true),
+        object: new $BucketModelField('object','object','dict','Object',true,undefined,undefined,{
+            '#': new $BucketModelField('','','unknown','',true,undefined,undefined)
         }),
-        delete_trx_id: new $BucketModelField('delete_trx_id','delete_trx_id','int','ID of Delete Transaction',false,true),
+        delete_trx_id: new $BucketModelField('delete_trx_id','delete_trx_id','int','ID of Delete Transaction',true),
     }),
     new $BucketGraph(),
     {}

--- a/src/engine/space.ts
+++ b/src/engine/space.ts
@@ -184,7 +184,9 @@ export class Space<
         Module extends $Module = $['modules'][M]
     >(globalName: `${M & string}::${K}`) {
         const [module, name] = globalName.split('::');
-        type Job = $Job & { name: K }
+        type Job = $Job & {
+            name: K
+        }
         return new JobBuilder<
             $, Module, Job
         >(

--- a/src/engine/util/parse.ts
+++ b/src/engine/util/parse.ts
@@ -9,7 +9,7 @@ import { NesoiDatetime } from '../data/datetime';
 import { NesoiFile } from '../data/file';
 import { NesoiDuration } from '../data/duration';
 
-export function parseBoolean(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseBoolean(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (value === 'true' || value === 1) {
         return true;
     }
@@ -22,7 +22,7 @@ export function parseBoolean(field: { path_raw: string, alias: string }, path: s
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'boolean' });    
 }
 
-export function parseDate(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseDate(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     // TODO: limit to date
     if (typeof value === 'string') {
         return NesoiDate.fromISO(value);
@@ -30,21 +30,21 @@ export function parseDate(field: { path_raw: string, alias: string }, path: stri
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'date' });
 }
     
-export function parseDatetime(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseDatetime(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         return NesoiDatetime.fromISO(value);
     }
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'datetime' });
 }
     
-export function parseDuration(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseDuration(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         return NesoiDuration.fromString(value);
     }
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'duration' });
 }
 
-export function parseDecimal(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseDecimal(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         return new NesoiDecimal(value);
     }
@@ -53,7 +53,7 @@ export function parseDecimal(field: { path_raw: string, alias: string }, path: s
 
 export function parseEnum(
     raw: Record<string, any>,
-    field: { path_raw: string, name: string, alias: string },
+    field: { pathRaw: string, name: string, alias: string },
     path: string[],
     value: any,
     options: string | readonly string[] | Record<string, any>,
@@ -107,7 +107,7 @@ export function parseEnum(
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'string' });
 }
 
-export function parseFile(field: { path_raw: string, name: string, alias: string }, path: string[], value: any, options?: {
+export function parseFile(field: { pathRaw: string, name: string, alias: string }, path: string[], value: any, options?: {
     maxsize?: number
     extnames?: string[]
 }) {
@@ -127,7 +127,7 @@ export function parseFile(field: { path_raw: string, name: string, alias: string
     return value;
 }
 
-export function parseFloat_(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseFloat_(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         const val = parseFloat(value);
         if (!Number.isNaN(val)) {
@@ -147,7 +147,7 @@ export async function parseId<
     Name extends BucketName<M>,
     View extends ViewName<M['buckets'][Name]> | undefined
 >(
-    field: { path_raw: string, alias: string },
+    field: { pathRaw: string, alias: string },
     path: string[],
     value: any,
     trx: AnyTrxNode,
@@ -170,7 +170,7 @@ export async function parseId<
     }; 
 }
 
-export function parseInt_(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseInt_(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         const val = parseInt(value);
         if (!Number.isNaN(val)) {
@@ -186,14 +186,14 @@ export function parseInt_(field: { path_raw: string, alias: string }, path: stri
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'integer' });
 }
 
-export function parseString(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseString(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string') {
         return value;
     }
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'string' });
 }
 
-export function parseStringOrNumber(field: { path_raw: string, alias: string }, path: string[], value: any) {
+export function parseStringOrNumber(field: { pathRaw: string, alias: string }, path: string[], value: any) {
     if (typeof value === 'string' || typeof value === 'number') {
         return value;
     }
@@ -201,7 +201,7 @@ export function parseStringOrNumber(field: { path_raw: string, alias: string }, 
 }
 
 export function parseDict(
-    field: { path_raw: string, alias: string, children?: $MessageTemplateFields },
+    field: { pathRaw: string, alias: string, children?: $MessageTemplateFields },
     path: string[],
     value: any
 ) {
@@ -211,7 +211,7 @@ export function parseDict(
             value?: any
         }> = {};
         for (const key in value) {
-            const _field = field.children!['__dict'];
+            const _field = field.children!['#'];
             children[key] = {
                 field: _field,
                 value: value[key]
@@ -222,8 +222,31 @@ export function parseDict(
     throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'dict' });
 }
 
+export function parseList(
+    field: { pathRaw: string, alias: string, children?: $MessageTemplateFields },
+    path: string[],
+    value: any
+) {
+    if (!Array.isArray(value)) {
+        throw NesoiError.Message.InvalidFieldType({ alias: field.alias, path: path.join('.'), value, type: 'list' });
+    }
+    const children: Record<string, {
+        field: $MessageTemplateField,
+        value?: any
+    }> = {};
+
+    for (let i = 0; i < value.length; i++) {
+        const _field = field.children!['#'];
+        children[i] = {
+            field: _field,
+            value: value[i]
+        };
+    }
+    return children
+}
+
 export function parseObj(
-    field: { path_raw: string, alias: string, children?: $MessageTemplateFields },
+    field: { pathRaw: string, alias: string, children?: $MessageTemplateFields },
     path: string[],
     value: any
 ) {
@@ -236,8 +259,8 @@ export function parseObj(
         }> = {};
         for (const key in field.children) {
             const _field = field.children[key] as $MessageTemplateField;
-            const key_raw = _field.path_raw.split('.')[path.length]
-            const key_parsed = _field.path_parsed.split('.')[path.length]
+            const key_raw = _field.pathRaw.split('.')[path.length]
+            const key_parsed = _field.pathParsed.split('.')[path.length]
             children[key_parsed] = {
                 field: _field,
                 value: value[key_raw]

--- a/src/engine/util/type.ts
+++ b/src/engine/util/type.ts
@@ -15,3 +15,5 @@ export type MergeUnion<T> = {
     [K in T extends T ? keyof T : never]:
         T extends { [J in K]: any } ? T[K] : never
 }
+
+export type UnionToIntersection<T> = { [K in T as K & string]: K }[any]

--- a/test-d/benchmark/replace.bnmk.ts
+++ b/test-d/benchmark/replace.bnmk.ts
@@ -1,0 +1,20 @@
+
+type Replace2<T extends string, S extends string, D extends string>
+    = T extends `${infer L}${S}${infer R}` ? `${L}${D}${Replace<R, S, D>}` : T
+
+type _Original = Replace<'a.#.b.#.c.#.d', '#', 'popopo'>
+type _v2 = Replace2<'a.#.b.#.c.#.d', '#', 'popopo'>
+type __v2 = Replace2<'a.#.b.#.c.#.d', '#', 'popopo'>
+type __Original = Replace<'a.#.b.#.c.#.d', '#', 'popopo'>
+
+type Replace<T extends string, S extends string, D extends string,
+  A extends string = ''> = T extends `${infer L}${S}${infer R}` ?
+  Replace<R, S, D, `${A}${L}${D}`> : `${A}${T}`
+
+// @ts-benchmark(v2)
+type v2 = Replace2<'a.#.b.#.c.#.d', '#', 'popopo'>
+
+// @ts-benchmark(original)
+type Original = Replace<'a.#.b.#.c.#.d', '#', 'popopo'>
+
+

--- a/test-d/benchmark/ts-benchmark.ts
+++ b/test-d/benchmark/ts-benchmark.ts
@@ -56,7 +56,7 @@ export class TypeScriptBenchmark {
         this.checker = this.program.getTypeChecker();
     }
 
-    public benchmark(n = 20) {
+    public benchmark(n = 30) {
         Log.info('benchmark' as any, 'check', `Benchmarking types of file ${colored(this.file, 'blue')}`)
 
         // // Copy file N times to avoid caching
@@ -229,6 +229,6 @@ export class TypeScriptBenchmark {
 
 }
 
-const bnmk = new TypeScriptBenchmark('/home/aboud/git/nesoi/test-d/benchmark/query.bnmk.ts');
+const bnmk = new TypeScriptBenchmark('/home/aboud/git/nesoi/test-d/benchmark/replace.bnmk.ts');
 
 bnmk.benchmark();

--- a/test-d/benchmark/union_to_inter.bnmk.ts
+++ b/test-d/benchmark/union_to_inter.bnmk.ts
@@ -1,0 +1,141 @@
+
+type FunctionUnion =
+    (() => void)
+    | ((a0: string) => void)
+    | ((a0: string, b0: number) => { c0: boolean })
+    | { b0: number, c0: string }
+    | ({ d0: boolean, e0: Date } & { f0: number })
+    | { g0: string[] }
+
+    | ((a1: string) => void)
+    | ((a1: string, b1: number) => { c1: boolean })
+    | { b1: number, c1: string }
+    | ({ d1: boolean, e1: Date } & { f1: number })
+    | { g1: string[] }
+
+    | ((a2: string) => void)
+    | ((a2: string, b2: number) => { c2: boolean })
+    | { b2: number, c2: string }
+    | ({ d2: boolean, e2: Date } & { f2: number })
+    | { g2: string[] }
+
+    | ((a3: string) => void)
+    | ((a3: string, b3: number) => { c3: boolean })
+    | { b3: number, c3: string }
+    | ({ d3: boolean, e3: Date } & { f3: number })
+    | { g3: string[] }
+
+    | ((a4: string) => void)
+    | ((a4: string, b4: number) => { c4: boolean })
+    | { b4: number, c4: string }
+    | ({ d4: boolean, e4: Date } & { f4: number })
+    | { g4: string[] }
+
+    | ((a5: string) => void)
+    | ((a5: string, b5: number) => { c5: boolean })
+    | { b5: number, c5: string }
+    | ({ d5: boolean, e5: Date } & { f5: number })
+    | { g5: string[] }
+
+    | ((a6: string) => void)
+    | ((a6: string, b6: number) => { c6: boolean })
+    | { b6: number, c6: string }
+    | ({ d6: boolean, e6: Date } & { f6: number })
+    | { g6: string[] }
+
+    | ((a7: string) => void)
+    | ((a7: string, b7: number) => { c7: boolean })
+    | { b7: number, c7: string }
+    | ({ d7: boolean, e7: Date } & { f7: number })
+    | { g7: string[] }
+
+    | ((a8: string) => void)
+    | ((a8: string, b8: number) => { c8: boolean })
+    | { b8: number, c8: string }
+    | ({ d8: boolean, e8: Date } & { f8: number })
+    | { g8: string[] }
+
+    | ((a9: string) => void)
+    | ((a9: string, b9: number) => { c9: boolean })
+    | { b9: number, c9: string }
+    | ({ d9: boolean, e9: Date } & { f9: number })
+    | { g9: string[] }
+    
+    | ((a10: string) => void)
+    | ((a10: string, b10: number) => { c10: boolean })
+    | { b10: number, c10: string }
+    | ({ d10: boolean, e10: Date } & { f10: number })
+    | { g10: string[] }
+
+    | ((a11: string) => void)
+    | ((a11: string, b11: number) => { c11: boolean })
+    | { b11: number, c11: string }
+    | ({ d11: boolean, e11: Date } & { f11: number })
+    | { g11: string[] }
+
+    | ((a12: string) => void)
+    | ((a12: string, b12: number) => { c12: boolean })
+    | { b12: number, c12: string }
+    | ({ d12: boolean, e12: Date } & { f12: number })
+    | { g12: string[] }
+
+    | ((a13: string) => void)
+    | ((a13: string, b13: number) => { c13: boolean })
+    | { b13: number, c13: string }
+    | ({ d13: boolean, e13: Date } & { f13: number })
+    | { g13: string[] }
+
+    | ((a14: string) => void)
+    | ((a14: string, b14: number) => { c14: boolean })
+    | { b14: number, c14: string }
+    | ({ d14: boolean, e14: Date } & { f14: number })
+    | { g14: string[] }
+
+    | ((a15: string) => void)
+    | ((a15: string, b15: number) => { c15: boolean })
+    | { b15: number, c15: string }
+    | ({ d15: boolean, e15: Date } & { f15: number })
+    | { g15: string[] }
+
+    | ((a16: string) => void)
+    | ((a16: string, b16: number) => { c16: boolean })
+    | { b16: number, c16: string }
+    | ({ d16: boolean, e16: Date } & { f16: number })
+    | { g16: string[] }
+
+    | ((a17: string) => void)
+    | ((a17: string, b17: number) => { c17: boolean })
+    | { b17: number, c17: string }
+    | ({ d17: boolean, e17: Date } & { f17: number })
+    | { g17: string[] }
+
+    | ((a18: string) => void)
+    | ((a18: string, b18: number) => { c18: boolean })
+    | { b18: number, c18: string }
+    | ({ d18: boolean, e18: Date } & { f18: number })
+    | { g18: string[] }
+
+    | ((a19: string) => void)
+    | ((a19: string, b19: number) => { c19: boolean })
+    | { b19: number, c19: string }
+    | ({ d19: boolean, e19: Date } & { f19: number })
+    | { g19: string[] }
+
+type utilityTypes_UnionToIntersection<T> = (T extends any
+    ? (k: T) => void
+    : never) extends (k: infer I) => void
+      ? I
+      : never;
+    
+// type UnionToIntersection<T> = { [K in T as K & string]: K }[any]
+type UnionToIntersection<T> = { [K in T as K & string]: K }[never]
+
+// @ts-benchmark(this version)
+type Intersection = UnionToIntersection<FunctionUnion>
+
+// @ts-benchmark(utility-types version)
+type utilityTypes_Intersection = utilityTypes_UnionToIntersection<FunctionUnion>
+
+type IsSimilar = 
+    (Intersection extends utilityTypes_Intersection ? 'yes' : 'no')
+    | (utilityTypes_Intersection extends Intersection ? 'yes' : 'no')

--- a/test-d/bucket.test-d.ts
+++ b/test-d/bucket.test-d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unused-imports/no-unused-vars */
 import { expectAssignable, expectType } from 'tsd';
 import { BucketBuilder } from '~/elements/entities/bucket/bucket.builder';
-import { BucketModelFieldBuilder, BucketModelFieldBuilders } from '~/elements/entities/bucket/model/bucket_model_field.builder';
+import { AnyBucketModelFieldBuilder, BucketModelFieldBuilders } from '~/elements/entities/bucket/model/bucket_model_field.builder';
 import { NesoiDate } from '~/engine/data/date';
 import { Mock } from './mock';
 import { NesoiDecimal } from '~/engine/data/decimal';
@@ -10,6 +10,7 @@ import { TrxNode } from '~/engine/transaction/trx_node';
 import { Infer } from './meta/types';
 import { NesoiDatetime } from '~/engine/data/datetime';
 import { NesoiDuration } from '~/engine/data/duration';
+import { BucketViewFieldFactory } from '~/elements/entities/bucket/view/bucket_view_field.builder';
 
 const _Mock = {
     module: 'MOCK_MODULE',
@@ -24,7 +25,7 @@ const _Mock = {
 
     type ModelReturn = ReturnType<Parameters<typeof builder.model>[0]>
     type ModelShouldRequireId = {
-        id: BucketModelFieldBuilder<any, any>
+        id: AnyBucketModelFieldBuilder
     } & BucketModelFieldBuilders<any>
     // TODO: find out why I can't use expectType here
     expectAssignable<ModelShouldRequireId>({} as ModelReturn)
@@ -99,7 +100,7 @@ const _Mock = {
                     })
                 }),
                 deepDict: $.dict($.int),
-                deepIntArray: $.int.array,
+                deepIntList: $.list($.int),
                 deepStringOptional: $.string.optional,
             });
 
@@ -125,10 +126,10 @@ const _Mock = {
                     }
                 },
                 deepDict: Record<string, number>,
-                deepIntArray: number[],
-                deepStringOptional: string | undefined,
+                deepIntList: number[],
+                deepStringOptional?: string | undefined | null,
             }
-            type DefaultObj = Parameters<typeof _obj.default>[0]
+            type DefaultObj = Infer<Parameters<typeof _obj.default>[0]>
             expectType<ExpectedObj>({} as DefaultObj)
 
             const _dict = $.dict($.int);
@@ -141,7 +142,7 @@ const _Mock = {
 }
 
 /**
- * test: Model .array.default(0) argument should match field type[]
+ * test: Model .List.default(0) argument should match field type[]
  */
 {
     new BucketBuilder(_Mock.module, _Mock.bucket)
@@ -150,47 +151,47 @@ const _Mock = {
             // DISABLED_TEST:
             // I wasn't able to find a solution for this yet.
             //  
-            // const _any = $.any.array;
+            // const _any = $.any.List;
             // type DefaultAny = Parameters<typeof _any.default>[0];
             // expectType<any[]>({} as DefaultAny)
 
-            const _boolean = $.boolean.array;
+            const _boolean = $.list($.boolean);
             type DefaultBoolean = Parameters<typeof _boolean.default>[0];
             expectType<boolean[]>({} as DefaultBoolean)
 
-            const _date = $.date.array;
+            const _date = $.list($.date);
             type DefaultDate = Parameters<typeof _date.default>[0];
             expectType<NesoiDate[]>({} as DefaultDate)
             
-            const _datetime = $.datetime.array;
+            const _datetime = $.list($.datetime);
             type DefaultDatetime = Parameters<typeof _datetime.default>[0];
             expectType<NesoiDatetime[]>({} as DefaultDatetime)
             
-            const _duration = $.duration.array;
+            const _duration = $.list($.duration);
             type DefaultDuration = Parameters<typeof _duration.default>[0];
             expectType<NesoiDuration[]>({} as DefaultDuration)
             
-            const _decimal = $.decimal().array;
+            const _decimal = $.list($.decimal());
             type DefaultDecimal = Parameters<typeof _decimal.default>[0];
             expectType<NesoiDecimal[]>({} as DefaultDecimal)
             
-            const _enum = $.enum(['a', 'b', 'c'] as const).array;
+            const _enum = $.list($.enum(['a', 'b', 'c'] as const));
             type DefaultEnum = Parameters<typeof _enum.default>[0]
             expectType<('a'| 'b' | 'c')[]>({} as DefaultEnum)
 
-            const _int = $.int.array;
+            const _int = $.list($.int);
             type DefaultInt = Parameters<typeof _int.default>[0]
             expectType<number[]>({} as DefaultInt)
 
-            const _float = $.float.array;
+            const _float = $.list($.float);
             type DefaultFloat = Parameters<typeof _float.default>[0]
             expectType<number[]>({} as DefaultFloat)
 
-            const _string = $.string.array;
+            const _string = $.list($.string);
             type DefaultString = Parameters<typeof _string.default>[0]
             expectType<string[]>({} as DefaultString)
 
-            const _obj = $.obj({
+            const _obj = $.list($.obj({
                 deepBoolean: $.boolean,
                 deepDate: $.date,
                 deepDatetime: $.datetime,
@@ -211,7 +212,7 @@ const _Mock = {
                         ok: $.boolean,
                     })
                 }),
-            }).array;
+            }));
             type ExpectedObj = {
                 deepBoolean: boolean,
                 deepDate: NesoiDate,
@@ -234,10 +235,10 @@ const _Mock = {
                     }
                 },
             }
-            type DefaultObj = Parameters<typeof _obj.default>[0]
+            type DefaultObj = Infer<Parameters<typeof _obj.default>[0]>
             expectType<ExpectedObj[]>({} as DefaultObj)
 
-            const _dict = $.dict($.int).array;
+            const _dict = $.list($.dict($.int));
             type DefaultDict = Parameters<typeof _dict.default>[0]
             expectType<Record<string, number>[]>({} as DefaultDict)
 
@@ -258,39 +259,39 @@ const _Mock = {
 
             const _boolean = $.boolean.optional;
             type DefaultBoolean = Parameters<typeof _boolean.default>[0];
-            expectType<boolean>({} as DefaultBoolean)
+            expectType<boolean | null | undefined>({} as DefaultBoolean)
 
             const _date = $.date.optional;
             type DefaultDate = Parameters<typeof _date.default>[0];
-            expectType<NesoiDate>({} as DefaultDate)
+            expectType<NesoiDate | null | undefined>({} as DefaultDate)
             
             const _datetime = $.datetime.optional;
             type DefaultDatetime = Parameters<typeof _datetime.default>[0];
-            expectType<NesoiDatetime>({} as DefaultDatetime)
+            expectType<NesoiDatetime | null | undefined>({} as DefaultDatetime)
             
             const _duration = $.duration.optional;
             type DefaultDuration = Parameters<typeof _duration.default>[0];
-            expectType<NesoiDuration>({} as DefaultDuration)
+            expectType<NesoiDuration | null | undefined>({} as DefaultDuration)
             
             const _decimal = $.decimal().optional;
             type DefaultDecimal = Parameters<typeof _decimal.default>[0];
-            expectType<NesoiDecimal>({} as DefaultDecimal)
+            expectType<NesoiDecimal | null | undefined>({} as DefaultDecimal)
             
             const _enum = $.enum(['a', 'b', 'c'] as const).optional;
             type DefaultEnum = Parameters<typeof _enum.default>[0]
-            expectType<('a'| 'b' | 'c')>({} as DefaultEnum)
+            expectType<('a'| 'b' | 'c') | null | undefined>({} as DefaultEnum)
 
             const _int = $.int.optional;
             type DefaultInt = Parameters<typeof _int.default>[0]
-            expectType<number>({} as DefaultInt)
+            expectType<number | null | undefined>({} as DefaultInt)
 
             const _float = $.float.optional;
             type DefaultFloat = Parameters<typeof _float.default>[0]
-            expectType<number>({} as DefaultFloat)
+            expectType<number | null | undefined>({} as DefaultFloat)
 
             const _string = $.string.optional;
             type DefaultString = Parameters<typeof _string.default>[0]
-            expectType<string>({} as DefaultString)
+            expectType<string | null | undefined>({} as DefaultString)
 
             const _obj = $.obj({
                 deepBoolean: $.boolean,
@@ -334,61 +335,61 @@ const _Mock = {
                     }
                 },
             }
-            type DefaultObj = Parameters<typeof _obj.default>[0]
-            expectType<ExpectedObj>({} as DefaultObj)
+            type DefaultObj = Infer<Parameters<typeof _obj.default>[0]>
+            expectType<ExpectedObj | null | undefined>({} as DefaultObj)
 
             const _dict = $.dict($.int).optional;
             type DefaultDict = Parameters<typeof _dict.default>[0]
-            expectType<Record<string, number>>({} as DefaultDict)
+            expectType<Record<string, number> | null | undefined>({} as DefaultDict)
 
             return { id: $.int }
         })
 }
 
 /**
- * test: Model .array.optional.default(0) argument should match field type[]
+ * test: Model .List.optional.default(0) argument should match field type[]
  */
 {
     new BucketBuilder(_Mock.module, _Mock.bucket)
         .model($ => {
 
-            const _any = $.any.array.optional;
+            const _any = $.list($.any).optional;
             type DefaultAny = Parameters<typeof _any.default>[0];
-            expectType<any[]>({} as DefaultAny)
+            expectType<any[] | null | undefined>({} as DefaultAny)
 
-            const _boolean = $.boolean.array.optional;
+            const _boolean = $.list($.boolean).optional;
             type DefaultBoolean = Parameters<typeof _boolean.default>[0];
-            expectType<boolean[]>({} as DefaultBoolean)
+            expectType<boolean[] | null | undefined>({} as DefaultBoolean)
 
-            const _date = $.date.array.optional;
+            const _date = $.list($.date).optional;
             type DefaultDate = Parameters<typeof _date.default>[0];
-            expectType<NesoiDate[]>({} as DefaultDate)
+            expectType<NesoiDate[] | null | undefined>({} as DefaultDate)
             
-            const _datetime = $.datetime.array.optional;
+            const _datetime = $.list($.datetime).optional;
             type DefaultDatetime = Parameters<typeof _datetime.default>[0];
-            expectType<NesoiDatetime[]>({} as DefaultDatetime)
+            expectType<NesoiDatetime[] | null | undefined>({} as DefaultDatetime)
             
-            const _duration = $.duration.array.optional;
+            const _duration = $.list($.duration).optional;
             type DefaultDuration = Parameters<typeof _duration.default>[0];
-            expectType<NesoiDuration[]>({} as DefaultDuration)
+            expectType<NesoiDuration[] | null | undefined>({} as DefaultDuration)
             
-            const _enum = $.enum(['a', 'b', 'c'] as const).array.optional;
+            const _enum = $.list($.enum(['a', 'b', 'c'] as const)).optional;
             type DefaultEnum = Parameters<typeof _enum.default>[0]
-            expectType<('a'| 'b' | 'c')[]>({} as DefaultEnum)
+            expectType<('a'| 'b' | 'c')[] | null | undefined>({} as DefaultEnum)
 
-            const _int = $.int.array.optional;
+            const _int = $.list($.int).optional;
             type DefaultInt = Parameters<typeof _int.default>[0]
-            expectType<number[]>({} as DefaultInt)
+            expectType<number[] | null | undefined>({} as DefaultInt)
 
-            const _float = $.float.array.optional;
+            const _float = $.list($.float).optional;
             type DefaultFloat = Parameters<typeof _float.default>[0]
-            expectType<number[]>({} as DefaultFloat)
+            expectType<number[] | null | undefined>({} as DefaultFloat)
 
-            const _string = $.string.array.optional;
+            const _string = $.list($.string).optional;
             type DefaultString = Parameters<typeof _string.default>[0]
-            expectType<string[]>({} as DefaultString)
+            expectType<string[] | null | undefined>({} as DefaultString)
 
-            const _obj = $.obj({
+            const _obj = $.list($.obj({
                 deepBoolean: $.boolean,
                 deepDate: $.date,
                 deepDatetime: $.datetime,
@@ -408,7 +409,7 @@ const _Mock = {
                         ok: $.boolean,
                     })
                 }),
-            }).array.optional;
+            })).optional;
             type ExpectedObj = {
                 deepBoolean: boolean,
                 deepDate: NesoiDate,
@@ -430,12 +431,12 @@ const _Mock = {
                     }
                 },
             }
-            type DefaultObj = Parameters<typeof _obj.default>[0]
-            expectType<ExpectedObj[]>({} as DefaultObj)
+            type DefaultObj = Infer<Parameters<typeof _obj.default>[0]>
+            expectType<ExpectedObj[] | null | undefined>({} as DefaultObj)
 
-            const _dict = $.dict($.int).array.optional;
+            const _dict = $.list($.dict($.int)).optional;
             type DefaultDict = Parameters<typeof _dict.default>[0]
-            expectType<Record<string, number>[]>({} as DefaultDict)
+            expectType<Record<string, number>[] | null | undefined>({} as DefaultDict)
 
             return { id: $.int }
         })
@@ -498,31 +499,31 @@ const _Mock = {
             }),
             pDict: $.dict($.int),
 
-            pAnyArray: $.any.array,
-            pBooleanArray: $.boolean.array,
-            pDateArray: $.date.array,
-            pDatetimeArray: $.datetime.array,
-            pDurationArray: $.duration.array,
-            pDecimalArray: $.decimal().array,
-            pEnumArray: $.enum(['a', 'b', 'c'] as const).array,
-            pIntArray: $.int.array,
-            pFloatArray: $.float.array,
-            pStringArray: $.string.array,
-            pObjArray: $.obj({
-                deepBooleanArray: $.boolean.array,
-                deepDateArray: $.date.array,
-                deepDatetimeArray: $.datetime.array,
-                deepDurationArray: $.duration.array,
-                deepDecimalArray: $.decimal().array,
-                deepEnumArray: $.enum(['1', '2', '3'] as const).array,
-                deepIntArray: $.int.array,
-                deepFloatArray: $.float.array,
-                deepStringArray: $.string.array,
-                deepObjArray: $.obj({
-                    okArray: $.boolean.array,
-                }).array
-            }).array,
-            pDictArray: $.dict($.int).array,
+            pAnyList: $.list($.any),
+            pBooleanList: $.list($.boolean),
+            pDateList: $.list($.date),
+            pDatetimeList: $.list($.datetime),
+            pDurationList: $.list($.duration),
+            pDecimalList: $.list($.decimal()),
+            pEnumList: $.list($.enum(['a', 'b', 'c'] as const)),
+            pIntList: $.list($.int),
+            pFloatList: $.list($.float),
+            pStringList: $.list($.string),
+            pObjList: $.list($.obj({
+                deepBooleanList: $.list($.boolean),
+                deepDateList: $.list($.date),
+                deepDatetimeList: $.list($.datetime),
+                deepDurationList: $.list($.duration),
+                deepDecimalList: $.list($.decimal()),
+                deepEnumList: $.list($.enum(['1', '2', '3'] as const)),
+                deepIntList: $.list($.int),
+                deepFloatList: $.list($.float),
+                deepStringList: $.list($.string),
+                deepObjList: $.list($.obj({
+                    okList: $.list($.boolean),
+                }))
+            })),
+            pDictList: $.list($.dict($.int)),
 
             pAnyOptional: $.any.optional,
             pBooleanOptional: $.boolean.optional,
@@ -550,65 +551,64 @@ const _Mock = {
             }).optional,
             pDictOptional: $.dict($.int).optional,
 
-            pAnyArrayOptional: $.any.array.optional,
-            pBooleanArrayOptional: $.boolean.array.optional,
-            pDateArrayOptional: $.date.array.optional,
-            pDatetimeArrayOptional: $.datetime.array.optional,
-            pDurationArrayOptional: $.duration.array.optional,
-            pDecimalArrayOptional: $.decimal().array.optional,
-            pEnumArrayOptional: $.enum(['a', 'b', 'c'] as const).array.optional,
-            pIntArrayOptional: $.int.array.optional,
-            pFloatArrayOptional: $.float.array.optional,
-            pStringArrayOptional: $.string.array.optional,
-            pObjArrayOptional: $.obj({
-                deepBooleanArrayOptional: $.boolean.array.optional,
-                deepDateArrayOptional: $.date.array.optional,
-                deepDatetimeArrayOptional: $.datetime.array.optional,
-                deepDurationArrayOptional: $.duration.array.optional,
-                deepDecimalArrayOptional: $.decimal().array.optional,
-                deepEnumArrayOptional: $.enum(['1', '2', '3'] as const).array.optional,
-                deepIntArrayOptional: $.int.array.optional,
-                deepFloatArrayOptional: $.float.array.optional,
-                deepStringArrayOptional: $.string.array.optional,
-                deepObjArrayOptional: $.obj({
-                    okArrayOptional: $.boolean.array.optional,
-                }).array.optional
-            }).array.optional,
-            pDictArrayOptional: $.dict($.int).array.optional,
+            pAnyListOptional: $.list($.any).optional,
+            pBooleanListOptional: $.list($.boolean).optional,
+            pDateListOptional: $.list($.date).optional,
+            pDatetimeListOptional: $.list($.datetime).optional,
+            pDurationListOptional: $.list($.duration).optional,
+            pDecimalListOptional: $.list($.decimal()).optional,
+            pEnumListOptional: $.list($.enum(['a', 'b', 'c'] as const)).optional,
+            pIntListOptional: $.list($.int).optional,
+            pFloatListOptional: $.list($.float).optional,
+            pStringListOptional: $.list($.string).optional,
+            pObjListOptional: $.list($.obj({
+                deepBooleanListOptional: $.list($.boolean).optional,
+                deepDateListOptional: $.list($.date).optional,
+                deepDatetimeListOptional: $.list($.datetime).optional,
+                deepDurationListOptional: $.list($.duration).optional,
+                deepDecimalListOptional: $.list($.decimal()).optional,
+                deepEnumListOptional: $.list($.enum(['1', '2', '3'] as const)).optional,
+                deepIntListOptional: $.list($.int).optional,
+                deepFloatListOptional: $.list($.float).optional,
+                deepStringListOptional: $.list($.string).optional,
+                deepObjListOptional: $.list($.obj({
+                    okListOptional: $.list($.boolean).optional,
+                })).optional
+            })).optional,
+            pDictListOptional: $.list($.dict($.int)).optional,
 
-            pAnyOptionalArray: $.any.optional.array,
-            pBooleanOptionalArray: $.boolean.optional.array,
-            pDateOptionalArray: $.date.optional.array,
-            pDatetimeOptionalArray: $.datetime.optional.array,
-            pDurationOptionalArray: $.duration.optional.array,
-            pDecimalOptionalArray: $.decimal().optional.array,
-            pEnumOptionalArray: $.enum(['a', 'b', 'c'] as const).optional.array,
-            pIntOptionalArray: $.int.optional.array,
-            pFloatOptionalArray: $.float.optional.array,
-            pStringOptionalArray: $.string.optional.array,
-            pObjOptionalArray: $.obj({
-                deepBooleanOptionalArray: $.boolean.optional.array,
-                deepDateOptionalArray: $.date.optional.array,
-                deepDatetimeOptionalArray: $.datetime.optional.array,
-                deepDurationOptionalArray: $.duration.optional.array,
-                deepDecimalOptionalArray: $.decimal().optional.array,
-                deepEnumOptionalArray: $.enum(['1', '2', '3'] as const).optional.array,
-                deepIntOptionalArray: $.int.optional.array,
-                deepFloatOptionalArray: $.float.optional.array,
-                deepStringOptionalArray: $.string.optional.array,
-                deepObjOptionalArray: $.obj({
-                    okOptionalArray: $.boolean.optional.array,
-                }).optional.array
-            }).optional.array,
-            pDictOptionalArray: $.dict($.int).optional.array,
-
+            pAnyOptionalList: $.list($.any.optional),
+            pBooleanOptionalList: $.list($.boolean.optional),
+            pDateOptionalList: $.list($.date.optional),
+            pDatetimeOptionalList: $.list($.datetime.optional),
+            pDurationOptionalList: $.list($.duration.optional),
+            pDecimalOptionalList: $.list($.decimal().optional),
+            pEnumOptionalList: $.list($.enum(['a', 'b', 'c'] as const).optional),
+            pIntOptionalList: $.list($.int.optional),
+            pFloatOptionalList: $.list($.float.optional),
+            pStringOptionalList: $.list($.string.optional),
+            pObjOptionalList: $.list($.obj({
+                deepBooleanOptionalList: $.list($.boolean.optional),
+                deepDateOptionalList: $.list($.date.optional),
+                deepDatetimeOptionalList: $.list($.datetime.optional),
+                deepDurationOptionalList: $.list($.duration.optional),
+                deepDecimalOptionalList: $.list($.decimal().optional),
+                deepEnumOptionalList: $.list($.enum(['1', '2', '3'] as const).optional),
+                deepIntOptionalList: $.list($.int.optional),
+                deepFloatOptionalList: $.list($.float.optional),
+                deepStringOptionalList: $.list($.string.optional),
+                deepObjOptionalList: $.list($.obj({
+                    okOptionalList: $.list($.boolean.optional),
+                }).optional)
+            }).optional),
+            pDictOptionalList: $.list($.dict($.int).optional),
         }))
         
         type ComputedModel = typeof builder extends BucketBuilder<any, any, infer X> ? X['#data'] : never;
-        type ComputedFieldpath = typeof builder extends BucketBuilder<any, any, infer X> ? X['#fieldpath'] : never;
-        
+        type ComputedModelpath = typeof builder extends BucketBuilder<any, any, infer X> ? X['#modelpath'] : never;
+                
         expectType<Mock.FullBucket['#data']>({} as Infer<ComputedModel>)
-        expectType<Mock.FullBucket['#fieldpath']>({} as ComputedFieldpath)
+        // expectType<Mock.FullBucket['#modelpath']>({} as ComputedModelpath)
 }
 
 /**
@@ -663,11 +663,16 @@ const _Mock = {
                     ok: $.boolean,
                 })
             }),
-            pDict: $.dict($.int)
+            pDict: $.dict($.int),
+            pList: $.list($.int)
         }))
         .view('test_view', $ => {
-            type ModelField = Parameters<typeof $.model>[0]
-            type ExpectedFieldName = 'id'
+            type B = typeof $ extends BucketViewFieldFactory<any, any, infer X> ? X : any;
+            type C = B['#modelpath'];
+
+
+            type Modelpath = Parameters<typeof $.model>[0]
+            type ExpectedModelpath = 'id'
                 | 'pAny'
                 | 'pBoolean'
                 | 'pDate'
@@ -678,6 +683,7 @@ const _Mock = {
                 | 'pFloat'
                 | 'pString'
                 | 'pObj'
+                | 'pObj.*'
                 | 'pObj.deepBoolean'
                 | 'pObj.deepDate'
                 | 'pObj.deepDatetime'
@@ -687,10 +693,17 @@ const _Mock = {
                 | 'pObj.deepFloat'
                 | 'pObj.deepString'
                 | 'pObj.deepObj'
+                | 'pObj.deepObj.*'
                 | 'pObj.deepObj.ok'
                 | 'pDict'
-                | 'pDict.#'
-            expectType<ExpectedFieldName>({} as ModelField)
+                | 'pDict.*'
+                | `pDict.$${number}`
+                | `pDict.${string}`
+                | 'pList'
+                | 'pList.*'
+                | `pList.$${number}`
+                | `pList.${number}`
+            expectType<ExpectedModelpath>({} as Modelpath)
             return {}
         })
 }

--- a/test-d/job.test-d.ts
+++ b/test-d/job.test-d.ts
@@ -33,13 +33,11 @@ const _Mock = {
 
 {
     const builder = new JobBuilder<Mock.Space, Mock.Module, Mock.VanillaJob>(_Mock.module, _Mock.job)
-        .messages($ => ({
-            inline_msg: {
-                a: $.string,
-                b: $.decimal(),
-                c: $.date,
-                d: $.id('mock'),
-            }
+        .message('inline_msg', $ => ({
+            a: $.string,
+            b: $.decimal(),
+            c: $.date,
+            d: $.id('mock'),
         }))
     
     type Module = typeof builder extends JobBuilder<any, infer X, any> ? X : never;
@@ -86,16 +84,14 @@ const _Mock = {
 
 {
     const builder = new JobBuilder<Mock.Space, Mock.Module, Mock.VanillaJob>(_Mock.module, _Mock.job)
-        .messages($ => ({
-            '': {
-                a: $.string
-            },
-            'inline': {
-                b: $.boolean
-            },
-            'inline2': {
-                b: $.boolean
-            },
+        .message('', $ => ({
+            a: $.string
+        }))
+        .message('inline', $ => ({
+            b: $.boolean
+        }))
+        .message('inline2', $ => ({
+            b: $.boolean
         }))
     type InputParams = Parameters<typeof builder.input>[number];
     expectType<keyof Mock.Module['messages']

--- a/test-d/mock.ts
+++ b/test-d/mock.ts
@@ -137,7 +137,7 @@ export namespace Mock {
             flags: boolean[]
             vanilla_id: number
         }
-        '#fieldpath': {
+        '#modelpath': {
             'id': string
             'name': string
             'volume': number,
@@ -151,6 +151,25 @@ export namespace Mock {
             'color.g': number
             'color.b': number
             'flags': boolean[]
+            'flags.*': boolean[]
+        }&{ [x in `flags.$${number}`]: boolean }&{
+            'vanilla_id': number
+        }
+        '#querypath': {
+            'id': string
+            'name': string
+            'volume': number,
+            'timestamp': NesoiDatetime
+            'color': {
+                'r': number
+                'g': number
+                'b': number
+            }
+            'color.r': number
+            'color.g': number
+            'color.b': number
+            'flags': boolean[]
+            'flags.*': boolean
             'flags.#': boolean
             'vanilla_id': number
         }
@@ -187,7 +206,12 @@ export namespace Mock {
             mock_id: string
             vanilla_id: number
         }
-        '#fieldpath': {
+        '#modelpath': {
+            'id': string
+            'mock_id': string
+            'vanilla_id': number
+        }
+        '#querypath': {
             'id': string
             'mock_id': string
             'vanilla_id': number
@@ -227,111 +251,113 @@ export namespace Mock {
             },
             pDict: Record<string, number>
     
-            pAnyArray: any[],
-            pBooleanArray: boolean[],
-            pDateArray: NesoiDate[],
-            pDatetimeArray: NesoiDatetime[],
-            pDurationArray: NesoiDuration[],
-            pDecimalArray: NesoiDecimal[],
-            pEnumArray: ('a' | 'b' | 'c')[],
-            pIntArray: number[],
-            pFloatArray: number[],
-            pStringArray: string[],
-            pObjArray: {
-                deepBooleanArray: boolean[],
-                deepDateArray: NesoiDate[],
-                deepDatetimeArray: NesoiDatetime[],
-                deepDurationArray: NesoiDuration[],
-                deepDecimalArray: NesoiDecimal[],
-                deepEnumArray: ('1' | '2' | '3')[],
-                deepIntArray: number[],
-                deepFloatArray: number[],
-                deepStringArray: string[],
-                deepObjArray: {
-                    okArray: boolean[],
+            pAnyList: any[],
+            pBooleanList: boolean[],
+            pDateList: NesoiDate[],
+            pDatetimeList: NesoiDatetime[],
+            pDurationList: NesoiDuration[],
+            pDecimalList: NesoiDecimal[],
+            pEnumList: ('a' | 'b' | 'c')[],
+            pIntList: number[],
+            pFloatList: number[],
+            pStringList: string[],
+            pObjList: {
+                deepBooleanList: boolean[],
+                deepDateList: NesoiDate[],
+                deepDatetimeList: NesoiDatetime[],
+                deepDurationList: NesoiDuration[],
+                deepDecimalList: NesoiDecimal[],
+                deepEnumList: ('1' | '2' | '3')[],
+                deepIntList: number[],
+                deepFloatList: number[],
+                deepStringList: string[],
+                deepObjList: {
+                    okList: boolean[],
                 }[]
             }[],
-            pDictArray: Record<string, number>[]
+            pDictList: Record<string, number>[]
     
-            pAnyOptional: any | undefined,
-            pBooleanOptional: boolean | undefined,
-            pDateOptional: NesoiDate | undefined,
-            pDatetimeOptional: NesoiDatetime | undefined,
-            pDurationOptional: NesoiDuration | undefined,
-            pDecimalOptional: NesoiDecimal | undefined,
-            pEnumOptional: 'a' | 'b' | 'c' | undefined,
-            pIntOptional: number | undefined,
-            pFloatOptional: number | undefined,
-            pStringOptional: string | undefined,
-            pObjOptional: {
-                deepBooleanOptional: boolean | undefined,
-                deepDateOptional: NesoiDate | undefined,
-                deepDatetimeOptional: NesoiDatetime | undefined,
-                deepDurationOptional: NesoiDuration | undefined,
-                deepDecimalOptional: NesoiDecimal | undefined,
-                deepEnumOptional: '1' | '2' | '3' | undefined,
-                deepIntOptional: number | undefined,
-                deepFloatOptional: number | undefined,
-                deepStringOptional: string | undefined,
-                deepObjOptional: {
-                    okOptional: boolean | undefined,
-                } | undefined
-            } | undefined,
-            pDictOptional: Record<string, number> | undefined
+            pAnyOptional?: any | null | undefined,
+            pBooleanOptional?: boolean | null | undefined,
+            pDateOptional?: NesoiDate | null | undefined,
+            pDatetimeOptional?: NesoiDatetime | null | undefined,
+            pDurationOptional?: NesoiDuration | null | undefined,
+            pDecimalOptional?: NesoiDecimal | null | undefined,
+            pEnumOptional?: 'a' | 'b' | 'c' | null | undefined,
+            pIntOptional?: number | null | undefined,
+            pFloatOptional?: number | null | undefined,
+            pStringOptional?: string | null | undefined,
+            pObjOptional?: {
+                deepBooleanOptional?: boolean | null | undefined,
+                deepDateOptional?: NesoiDate | null | undefined,
+                deepDatetimeOptional?: NesoiDatetime | null | undefined,
+                deepDurationOptional?: NesoiDuration | null | undefined,
+                deepDecimalOptional?: NesoiDecimal | null | undefined,
+                deepEnumOptional?: '1' | '2' | '3' | null | undefined,
+                deepIntOptional?: number | null | undefined,
+                deepFloatOptional?: number | null | undefined,
+                deepStringOptional?: string | null | undefined,
+                deepObjOptional?: {
+                    okOptional?: boolean | null | undefined,
+                } | null | undefined
+            } | null | undefined,
+            pDictOptional?: Record<string, number> | null | undefined
     
-            pAnyArrayOptional: any[] | undefined,
-            pBooleanArrayOptional: boolean[] | undefined,
-            pDateArrayOptional: NesoiDate[] | undefined,
-            pDatetimeArrayOptional: NesoiDatetime[] | undefined,
-            pDurationArrayOptional: NesoiDuration[] | undefined,
-            pDecimalArrayOptional: NesoiDecimal[] | undefined,
-            pEnumArrayOptional: ('a' | 'b' | 'c')[] | undefined,
-            pIntArrayOptional: number[] | undefined,
-            pFloatArrayOptional: number[] | undefined,
-            pStringArrayOptional: string[] | undefined,
-            pObjArrayOptional: {
-                deepBooleanArrayOptional: boolean[] | undefined,
-                deepDateArrayOptional: NesoiDate[] | undefined,
-                deepDatetimeArrayOptional: NesoiDatetime[] | undefined,
-                deepDurationArrayOptional: NesoiDuration[] | undefined,
-                deepDecimalArrayOptional: NesoiDecimal[] | undefined,
-                deepEnumArrayOptional: ('1' | '2' | '3')[] | undefined,
-                deepIntArrayOptional: number[] | undefined,
-                deepFloatArrayOptional: number[] | undefined,
-                deepStringArrayOptional: string[] | undefined,
-                deepObjArrayOptional: {
-                    okArrayOptional: boolean[] | undefined,
-                }[] | undefined
-            }[] | undefined,
-            pDictArrayOptional: Record<string, number>[] | undefined
+            pAnyListOptional?: any[] | null | undefined,
+            pBooleanListOptional?: boolean[] | null | undefined,
+            pDateListOptional?: NesoiDate[] | null | undefined,
+            pDatetimeListOptional?: NesoiDatetime[] | null | undefined,
+            pDurationListOptional?: NesoiDuration[] | null | undefined,
+            pDecimalListOptional?: NesoiDecimal[] | null | undefined,
+            pEnumListOptional?: ('a' | 'b' | 'c')[] | null | undefined,
+            pIntListOptional?: number[] | null | undefined,
+            pFloatListOptional?: number[] | null | undefined,
+            pStringListOptional?: string[] | null | undefined,
+            pObjListOptional?: {
+                deepBooleanListOptional?: boolean[] | null | undefined,
+                deepDateListOptional?: NesoiDate[] | null | undefined,
+                deepDatetimeListOptional?: NesoiDatetime[] | null | undefined,
+                deepDurationListOptional?: NesoiDuration[] | null | undefined,
+                deepDecimalListOptional?: NesoiDecimal[] | null | undefined,
+                deepEnumListOptional?: ('1' | '2' | '3')[] | null | undefined,
+                deepIntListOptional?: number[] | null | undefined,
+                deepFloatListOptional?: number[] | null | undefined,
+                deepStringListOptional?: string[] | null | undefined,
+                deepObjListOptional?: {
+                    okListOptional?: boolean[] | null | undefined,
+                }[] | null | undefined
+            }[] | null | undefined,
+            pDictListOptional?: Record<string, number>[] | null | undefined
 
-            pAnyOptionalArray: any[] | undefined,
-            pBooleanOptionalArray: boolean[] | undefined,
-            pDateOptionalArray: NesoiDate[] | undefined,
-            pDatetimeOptionalArray: NesoiDatetime[] | undefined,
-            pDurationOptionalArray: NesoiDuration[] | undefined,
-            pDecimalOptionalArray: NesoiDecimal[] | undefined,
-            pEnumOptionalArray: ('a' | 'b' | 'c')[] | undefined,
-            pIntOptionalArray: number[] | undefined,
-            pFloatOptionalArray: number[] | undefined,
-            pStringOptionalArray: string[] | undefined,
-            pObjOptionalArray: {
-                deepBooleanOptionalArray: boolean[] | undefined,
-                deepDateOptionalArray: NesoiDate[] | undefined,
-                deepDatetimeOptionalArray: NesoiDatetime[] | undefined,
-                deepDurationOptionalArray: NesoiDuration[] | undefined,
-                deepDecimalOptionalArray: NesoiDecimal[] | undefined,
-                deepEnumOptionalArray: ('1' | '2' | '3')[] | undefined,
-                deepIntOptionalArray: number[] | undefined,
-                deepFloatOptionalArray: number[] | undefined,
-                deepStringOptionalArray: string[] | undefined,
-                deepObjOptionalArray: {
-                    okOptionalArray: boolean[] | undefined,
-                }[] | undefined
-            }[] | undefined,
-            pDictOptionalArray: Record<string, number>[] | undefined
+            pAnyOptionalList: (any | null | undefined)[],
+            pBooleanOptionalList: (boolean | null | undefined)[],
+            pDateOptionalList: (NesoiDate | null | undefined)[],
+            pDatetimeOptionalList: (NesoiDatetime | null | undefined)[],
+            pDurationOptionalList: (NesoiDuration | null | undefined)[],
+            pDecimalOptionalList: (NesoiDecimal | null | undefined)[],
+            pEnumOptionalList: (('a' | 'b' | 'c') | null | undefined)[],
+            pIntOptionalList: (number | null | undefined)[],
+            pFloatOptionalList: (number | null | undefined)[],
+            pStringOptionalList: (string | null | undefined)[],
+            pObjOptionalList: ({
+                deepBooleanOptionalList: (boolean | null | undefined)[],
+                deepDateOptionalList: (NesoiDate | null | undefined)[],
+                deepDatetimeOptionalList: (NesoiDatetime | null | undefined)[],
+                deepDurationOptionalList: (NesoiDuration | null | undefined)[],
+                deepDecimalOptionalList: (NesoiDecimal | null | undefined)[],
+                deepEnumOptionalList: (('1' | '2' | '3') | null | undefined)[],
+                deepIntOptionalList: (number | null | undefined)[],
+                deepFloatOptionalList: (number | null | undefined)[],
+                deepStringOptionalList: (string | null | undefined)[],
+                deepObjOptionalList: ({
+                    okOptionalList: (boolean | null | undefined)[],
+                } | null | undefined)[]
+            } | null | undefined)[],
+            pDictOptionalList: (Record<string, number> | null | undefined)[]
         }
-        '#fieldpath': {
+
+        // TODO: rewrite modelpath
+        '#modelpath': {
             'id': number
             'pAny': any
             'pBoolean': boolean
@@ -371,281 +397,290 @@ export namespace Mock {
             }
             'pObj.deepObj.ok': boolean
             'pDict': Record<string, number>
-            'pDict.#': number
-
-            'pAnyArray': any[]
-            'pAnyArray.#': any
-            'pBooleanArray': boolean[]
-            'pBooleanArray.#': boolean
-            'pDateArray': NesoiDate[]
-            'pDateArray.#': NesoiDate
-            'pDatetimeArray': NesoiDatetime[]
-            'pDatetimeArray.#': NesoiDatetime
-            'pDurationArray': NesoiDuration[]
-            'pDurationArray.#': NesoiDuration
-            'pDecimalArray': NesoiDecimal[]
-            'pDecimalArray.#': NesoiDecimal
-            'pEnumArray': ('a' | 'b' | 'c')[]
-            'pEnumArray.#': ('a' | 'b' | 'c')
-            'pIntArray': number[]
-            'pIntArray.#': number
-            'pFloatArray': number[]
-            'pFloatArray.#': number
-            'pStringArray': string[]
-            'pStringArray.#': string
-            'pObjArray': {
-                'deepBooleanArray': boolean[]
-                'deepDateArray': NesoiDate[]
-                'deepDatetimeArray': NesoiDatetime[]
-                'deepDurationArray': NesoiDuration[]
-                'deepDecimalArray': NesoiDecimal[]
-                'deepEnumArray': ('1' | '2' | '3')[]
-                'deepIntArray': number[]
-                'deepFloatArray': number[]
-                'deepStringArray': string[]
-                'deepObjArray': {
-                    'okArray': boolean[]
+        } & { [x in `pDict.${string}`]: number } & {
+            'pAnyList': any[]
+            'pAnyList.*': any[]
+        } & { [x in `pAnyList.${number}`]: any } & {
+            'pBooleanList': boolean[]
+            'pBooleanList.*': boolean[]
+        } & { [x in `pBooleanList.${number}`]: boolean } & {
+            'pDateList': NesoiDate[]
+            'pDateList.*': NesoiDate[]
+        } & { [x in `pDateList.${number}`]: NesoiDate } & {
+            'pDatetimeList': NesoiDatetime[]
+            'pDatetimeList.*': NesoiDatetime[]
+        } & { [x in `pDatetimeList.${number}`]: NesoiDatetime } & {
+            'pDurationList': NesoiDuration[]
+            'pDurationList.*': NesoiDuration[]
+        } & { [x in `pDurationList.${number}`]: NesoiDuration } & {
+            'pDecimalList': NesoiDecimal[]
+            'pDecimalList.*': NesoiDecimal[]
+        } & { [x in `pDecimalList.${number}`]: NesoiDecimal } & {
+            'pEnumList': ('a' | 'b' | 'c')[]
+            'pEnumList.*': ('a' | 'b' | 'c')[]
+        } & { [x in `pEnumList.${number}`]: ('a' | 'b' | 'c') } & {
+            'pIntList': number[]
+            'pIntList.*': number[]
+        } & { [x in `pIntList.${number}`]: number } & {
+            'pFloatList': number[]
+            'pFloatList.*': number[]
+        } & { [x in `pFloatList.${number}`]: number } & {
+            'pStringList': string[]
+            'pStringList.*': string[]
+        } & { [x in `pStringList.${number}`]: string } & {
+            'pObjList': {
+                'deepBooleanList': boolean[]
+                'deepDateList': NesoiDate[]
+                'deepDatetimeList': NesoiDatetime[]
+                'deepDurationList': NesoiDuration[]
+                'deepDecimalList': NesoiDecimal[]
+                'deepEnumList': ('1' | '2' | '3')[]
+                'deepIntList': number[]
+                'deepFloatList': number[]
+                'deepStringList': string[]
+                'deepObjList': {
+                    'okList': boolean[]
                 }[]
             }[]
-            'pObjArray.#': {
-                'deepBooleanArray': boolean[]
-                'deepDateArray': NesoiDate[]
-                'deepDatetimeArray': NesoiDatetime[]
-                'deepDurationArray': NesoiDuration[]
-                'deepDecimalArray': NesoiDecimal[]
-                'deepEnumArray': ('1' | '2' | '3')[]
-                'deepIntArray': number[]
-                'deepFloatArray': number[]
-                'deepStringArray': string[]
-                'deepObjArray': {
-                    'okArray': boolean[]
+            } & { [x in `pObjList.${number}`]: { } & {
+                'deepBooleanList': boolean[]
+                'deepDateList': NesoiDate[]
+                'deepDatetimeList': NesoiDatetime[]
+                'deepDurationList': NesoiDuration[]
+                'deepDecimalList': NesoiDecimal[]
+                'deepEnumList': ('1' | '2' | '3')[]
+                'deepIntList': number[]
+                'deepFloatList': number[]
+                'deepStringList': string[]
+                'deepObjList': {
+                    'okList': boolean[]
                 }[]
             }
-            'pObjArray.#.deepBooleanArray': boolean[]
-            'pObjArray.#.deepBooleanArray.#': boolean
-            'pObjArray.#.deepDateArray': NesoiDate[]
-            'pObjArray.#.deepDateArray.#': NesoiDate
-            'pObjArray.#.deepDatetimeArray': NesoiDatetime[]
-            'pObjArray.#.deepDatetimeArray.#': NesoiDatetime
-            'pObjArray.#.deepDurationArray': NesoiDuration[]
-            'pObjArray.#.deepDurationArray.#': NesoiDuration
-            'pObjArray.#.deepDecimalArray': NesoiDecimal[]
-            'pObjArray.#.deepDecimalArray.#': NesoiDecimal
-            'pObjArray.#.deepEnumArray': ('1' | '2' | '3')[]
-            'pObjArray.#.deepEnumArray.#': ('1' | '2' | '3')
-            'pObjArray.#.deepIntArray': number[]
-            'pObjArray.#.deepIntArray.#': number
-            'pObjArray.#.deepFloatArray': number[]
-            'pObjArray.#.deepFloatArray.#': number
-            'pObjArray.#.deepStringArray': string[]
-            'pObjArray.#.deepStringArray.#': string
-            'pObjArray.#.deepObjArray': {
-                'okArray': boolean[]
+            } & { [x in `pObjList.${number}.deepBooleanList`]: boolean[] } & {
+            } & { [x in `pObjList.${number}.deepBooleanList.${number}`]: boolean } & {
+            } & { [x in `pObjList.${number}.deepDateList`]: NesoiDate[] } & {
+            } & { [x in `pObjList.${number}.deepDateList.${number}`]: NesoiDate } & {
+            } & { [x in `pObjList.${number}.deepDatetimeList`]: NesoiDatetime[] } & {
+            } & { [x in `pObjList.${number}.deepDatetimeList.${number}`]: NesoiDatetime } & {
+            } & { [x in `pObjList.${number}.deepDurationList`]: NesoiDuration[] } & {
+            } & { [x in `pObjList.${number}.deepDurationList.${number}`]: NesoiDuration } & {
+            } & { [x in `pObjList.${number}.deepDecimalList`]: NesoiDecimal[] } & {
+            } & { [x in `pObjList.${number}.deepDecimalList.${number}`]: NesoiDecimal } & {
+            } & { [x in `pObjList.${number}.deepEnumList`]: ('1' | '2' | '3')[] } & {
+            } & { [x in `pObjList.${number}.deepEnumList.${number}`]: ('1' | '2' | '3') } & {
+            } & { [x in `pObjList.${number}.deepIntList`]: number[] } & {
+            } & { [x in `pObjList.${number}.deepIntList.${number}`]: number } & {
+            } & { [x in `pObjList.${number}.deepFloatList`]: number[] } & {
+            } & { [x in `pObjList.${number}.deepFloatList.${number}`]: number } & {
+            } & { [x in `pObjList.${number}.deepStringList`]: string[] } & {
+            } & { [x in `pObjList.${number}.deepStringList.${number}`]: string } & {
+            } & { [x in `pObjList.${number}.deepObjList`]: { } & {
+                'okList': boolean[]
             }[]
-            'pObjArray.#.deepObjArray.#': {
-                'okArray': boolean[]
+            } & { [x in `pObjList.${number}.deepObjList.${number}`]: { } & {
+                'okList': boolean[]
             }
-            'pObjArray.#.deepObjArray.#.okArray': boolean[]
-            'pObjArray.#.deepObjArray.#.okArray.#': boolean
-            'pDictArray': Record<string, number>[]
-            'pDictArray.#': Record<string, number>
-            'pDictArray.#.#': number
+            } & { [x in `pObjList.${number}.deepObjList.${number}.okList`]: boolean[] } & {
+            } & { [x in `pObjList.${number}.deepObjList.${number}.okList.${number}`]: boolean } & {
+            'pDictList': Record<string, number>[]
+            } & { [x in `pDictList.${number}`]: Record<string, number> } & {
+            } & { [x in `pDictList.${number}.${string}`]: number } & {
 
-            'pAnyOptional': any | undefined
-            'pBooleanOptional': boolean | undefined
-            'pDateOptional': NesoiDate | undefined
-            'pDatetimeOptional': NesoiDatetime | undefined
-            'pDurationOptional': NesoiDuration | undefined
-            'pDecimalOptional': NesoiDecimal | undefined
-            'pEnumOptional': 'a' | 'b' | 'c' | undefined
-            'pIntOptional': number | undefined
-            'pFloatOptional': number | undefined
-            'pStringOptional': string | undefined
-            'pObjOptional': {
-                'deepBooleanOptional': boolean | undefined
-                'deepDateOptional': NesoiDate | undefined
-                'deepDatetimeOptional': NesoiDatetime | undefined
-                'deepDurationOptional': NesoiDuration | undefined
-                'deepDecimalOptional': NesoiDecimal | undefined
-                'deepEnumOptional': '1' | '2' | '3' | undefined
-                'deepIntOptional': number | undefined
-                'deepFloatOptional': number | undefined
-                'deepStringOptional': string | undefined
-                'deepObjOptional': {
-                    'okOptional': boolean | undefined
-                } | undefined
-            } | undefined
-            'pObjOptional.deepBooleanOptional': boolean | undefined
-            'pObjOptional.deepDateOptional': NesoiDate | undefined
-            'pObjOptional.deepDatetimeOptional': NesoiDatetime | undefined
-            'pObjOptional.deepDurationOptional': NesoiDuration | undefined
-            'pObjOptional.deepDecimalOptional': NesoiDecimal | undefined
-            'pObjOptional.deepEnumOptional': '1' | '2' | '3' | undefined
-            'pObjOptional.deepIntOptional': number | undefined
-            'pObjOptional.deepFloatOptional': number | undefined
-            'pObjOptional.deepStringOptional': string | undefined
-            'pObjOptional.deepObjOptional': {
-                'okOptional': boolean | undefined
-            } | undefined
-            'pObjOptional.deepObjOptional.okOptional': boolean | undefined
-            'pDictOptional': Record<string, number> | undefined
-            'pDictOptional.#': number | undefined
+            // 'pAnyOptional': any | null | undefined
+            // 'pBooleanOptional': boolean | null | undefined
+            // 'pDateOptional': NesoiDate | null | undefined
+            // 'pDatetimeOptional': NesoiDatetime | null | undefined
+            // 'pDurationOptional': NesoiDuration | null | undefined
+            // 'pDecimalOptional': NesoiDecimal | null | undefined
+            // 'pEnumOptional': 'a' | 'b' | 'c' | null | undefined
+            // 'pIntOptional': number | null | undefined
+            // 'pFloatOptional': number | null | undefined
+            // 'pStringOptional': string | null | undefined
+            // 'pObjOptional': {
+            //     'deepBooleanOptional'?: boolean | null | undefined
+            //     'deepDateOptional'?: NesoiDate | null | undefined
+            //     'deepDatetimeOptional'?: NesoiDatetime | null | undefined
+            //     'deepDurationOptional'?: NesoiDuration | null | undefined
+            //     'deepDecimalOptional'?: NesoiDecimal | null | undefined
+            //     'deepEnumOptional'?: '1' | '2' | '3' | null | undefined
+            //     'deepIntOptional'?: number | null | undefined
+            //     'deepFloatOptional'?: number | null | undefined
+            //     'deepStringOptional'?: string | null | undefined
+            //     'deepObjOptional'?: {
+            //         'okOptional'?: boolean | null | undefined
+            //     } | null | undefined
+            // } | null | undefined
+            // 'pObjOptional.deepBooleanOptional': boolean | null | undefined
+            // 'pObjOptional.deepDateOptional': NesoiDate | null | undefined
+            // 'pObjOptional.deepDatetimeOptional': NesoiDatetime | null | undefined
+            // 'pObjOptional.deepDurationOptional': NesoiDuration | null | undefined
+            // 'pObjOptional.deepDecimalOptional': NesoiDecimal | null | undefined
+            // 'pObjOptional.deepEnumOptional': '1' | '2' | '3' | null | undefined
+            // 'pObjOptional.deepIntOptional': number | null | undefined
+            // 'pObjOptional.deepFloatOptional': number | null | undefined
+            // 'pObjOptional.deepStringOptional': string | null | undefined
+            // 'pObjOptional.deepObjOptional': {
+            //     'okOptional'?: boolean | null | undefined
+            // } | null | undefined
+            // 'pObjOptional.deepObjOptional.okOptional': boolean | null | undefined
+            // 'pDictOptional': Record<string, number> | null | undefined
+            // 'pDictOptional.#': number | null | undefined
 
-            'pAnyArrayOptional': any[] | undefined
-            'pAnyArrayOptional.#': any | undefined
-            'pBooleanArrayOptional': boolean[] | undefined
-            'pBooleanArrayOptional.#': boolean | undefined
-            'pDateArrayOptional': NesoiDate[] | undefined
-            'pDateArrayOptional.#': NesoiDate | undefined
-            'pDatetimeArrayOptional': NesoiDatetime[] | undefined
-            'pDatetimeArrayOptional.#': NesoiDatetime | undefined
-            'pDurationArrayOptional': NesoiDuration[] | undefined
-            'pDurationArrayOptional.#': NesoiDuration | undefined
-            'pDecimalArrayOptional': NesoiDecimal[] | undefined
-            'pDecimalArrayOptional.#': NesoiDecimal | undefined
-            'pEnumArrayOptional': ('a' | 'b' | 'c')[] | undefined
-            'pEnumArrayOptional.#': ('a' | 'b' | 'c') | undefined
-            'pIntArrayOptional': number[] | undefined
-            'pIntArrayOptional.#': number | undefined
-            'pFloatArrayOptional': number[] | undefined
-            'pFloatArrayOptional.#': number | undefined
-            'pStringArrayOptional': string[] | undefined
-            'pStringArrayOptional.#': string | undefined
-            'pObjArrayOptional': {
-                'deepBooleanArrayOptional': boolean[] | undefined
-                'deepDateArrayOptional': NesoiDate[] | undefined
-                'deepDatetimeArrayOptional': NesoiDatetime[] | undefined
-                'deepDurationArrayOptional': NesoiDuration[] | undefined
-                'deepDecimalArrayOptional': NesoiDecimal[] | undefined
-                'deepEnumArrayOptional': ('1' | '2' | '3')[] | undefined
-                'deepIntArrayOptional': number[] | undefined
-                'deepFloatArrayOptional': number[] | undefined
-                'deepStringArrayOptional': string[] | undefined
-                'deepObjArrayOptional': {
-                    'okArrayOptional': boolean[] | undefined
-                }[] | undefined
-            }[] | undefined
-            'pObjArrayOptional.#': {
-                'deepBooleanArrayOptional': boolean[] | undefined
-                'deepDateArrayOptional': NesoiDate[] | undefined
-                'deepDatetimeArrayOptional': NesoiDatetime[] | undefined
-                'deepDurationArrayOptional': NesoiDuration[] | undefined
-                'deepDecimalArrayOptional': NesoiDecimal[] | undefined
-                'deepEnumArrayOptional': ('1' | '2' | '3')[] | undefined
-                'deepIntArrayOptional': number[] | undefined
-                'deepFloatArrayOptional': number[] | undefined
-                'deepStringArrayOptional': string[] | undefined
-                'deepObjArrayOptional': {
-                    'okArrayOptional': boolean[] | undefined
-                }[] | undefined
-            } | undefined
-            'pObjArrayOptional.#.deepBooleanArrayOptional': boolean[] | undefined
-            'pObjArrayOptional.#.deepBooleanArrayOptional.#': boolean | undefined
-            'pObjArrayOptional.#.deepDateArrayOptional': NesoiDate[] | undefined
-            'pObjArrayOptional.#.deepDateArrayOptional.#': NesoiDate | undefined
-            'pObjArrayOptional.#.deepDatetimeArrayOptional': NesoiDatetime[] | undefined
-            'pObjArrayOptional.#.deepDatetimeArrayOptional.#': NesoiDatetime | undefined
-            'pObjArrayOptional.#.deepDurationArrayOptional': NesoiDuration[] | undefined
-            'pObjArrayOptional.#.deepDurationArrayOptional.#': NesoiDuration | undefined
-            'pObjArrayOptional.#.deepDecimalArrayOptional': NesoiDecimal[] | undefined
-            'pObjArrayOptional.#.deepDecimalArrayOptional.#': NesoiDecimal | undefined
-            'pObjArrayOptional.#.deepEnumArrayOptional': ('1' | '2' | '3')[] | undefined
-            'pObjArrayOptional.#.deepEnumArrayOptional.#': ('1' | '2' | '3') | undefined
-            'pObjArrayOptional.#.deepIntArrayOptional': number[] | undefined
-            'pObjArrayOptional.#.deepIntArrayOptional.#': number | undefined
-            'pObjArrayOptional.#.deepFloatArrayOptional': number[] | undefined
-            'pObjArrayOptional.#.deepFloatArrayOptional.#': number | undefined
-            'pObjArrayOptional.#.deepStringArrayOptional': string[] | undefined
-            'pObjArrayOptional.#.deepStringArrayOptional.#': string | undefined
-            'pObjArrayOptional.#.deepObjArrayOptional': {
-                'okArrayOptional': boolean[] | undefined
-            }[] | undefined
-            'pObjArrayOptional.#.deepObjArrayOptional.#': {
-                'okArrayOptional': boolean[] | undefined
-            } | undefined
-            'pObjArrayOptional.#.deepObjArrayOptional.#.okArrayOptional': boolean[] | undefined
-            'pObjArrayOptional.#.deepObjArrayOptional.#.okArrayOptional.#': boolean | undefined
-            'pDictArrayOptional': Record<string, number>[] | undefined
-            'pDictArrayOptional.#': Record<string, number> | undefined
-            'pDictArrayOptional.#.#': number | undefined
+            // 'pAnyListOptional': any[] | null | undefined
+            // 'pAnyListOptional.#': any | null | undefined
+            // 'pBooleanListOptional': boolean[] | null | undefined
+            // 'pBooleanListOptional.#': boolean | null | undefined
+            // 'pDateListOptional': NesoiDate[] | null | undefined
+            // 'pDateListOptional.#': NesoiDate | null | undefined
+            // 'pDatetimeListOptional': NesoiDatetime[] | null | undefined
+            // 'pDatetimeListOptional.#': NesoiDatetime | null | undefined
+            // 'pDurationListOptional': NesoiDuration[] | null | undefined
+            // 'pDurationListOptional.#': NesoiDuration | null | undefined
+            // 'pDecimalListOptional': NesoiDecimal[] | null | undefined
+            // 'pDecimalListOptional.#': NesoiDecimal | null | undefined
+            // 'pEnumListOptional': ('a' | 'b' | 'c')[] | null | undefined
+            // 'pEnumListOptional.#': ('a' | 'b' | 'c') | null | undefined
+            // 'pIntListOptional': number[] | null | undefined
+            // 'pIntListOptional.#': number | null | undefined
+            // 'pFloatListOptional': number[] | null | undefined
+            // 'pFloatListOptional.#': number | null | undefined
+            // 'pStringListOptional': string[] | null | undefined
+            // 'pStringListOptional.#': string | null | undefined
+            // 'pObjListOptional': {
+            //     'deepBooleanListOptional'?: boolean[] | null | undefined
+            //     'deepDateListOptional'?: NesoiDate[] | null | undefined
+            //     'deepDatetimeListOptional'?: NesoiDatetime[] | null | undefined
+            //     'deepDurationListOptional'?: NesoiDuration[] | null | undefined
+            //     'deepDecimalListOptional'?: NesoiDecimal[] | null | undefined
+            //     'deepEnumListOptional'?: ('1' | '2' | '3')[] | null | undefined
+            //     'deepIntListOptional'?: number[] | null | undefined
+            //     'deepFloatListOptional'?: number[] | null | undefined
+            //     'deepStringListOptional'?: string[] | null | undefined
+            //     'deepObjListOptional'?: {
+            //         'okListOptional'?: boolean[] | null | undefined
+            //     }[] | null | undefined
+            // }[] | null | undefined
+            // 'pObjListOptional.#': {
+            //     'deepBooleanListOptional'?: boolean[] | null | undefined
+            //     'deepDateListOptional'?: NesoiDate[] | null | undefined
+            //     'deepDatetimeListOptional'?: NesoiDatetime[] | null | undefined
+            //     'deepDurationListOptional'?: NesoiDuration[] | null | undefined
+            //     'deepDecimalListOptional'?: NesoiDecimal[] | null | undefined
+            //     'deepEnumListOptional'?: ('1' | '2' | '3')[] | null | undefined
+            //     'deepIntListOptional'?: number[] | null | undefined
+            //     'deepFloatListOptional'?: number[] | null | undefined
+            //     'deepStringListOptional'?: string[] | null | undefined
+            //     'deepObjListOptional'?: {
+            //         'okListOptional'?: boolean[] | null | undefined
+            //     }[] | null | undefined
+            // } | null | undefined
+            // 'pObjListOptional.#.deepBooleanListOptional': boolean[] | null | undefined
+            // 'pObjListOptional.#.deepBooleanListOptional.#': boolean | null | undefined
+            // 'pObjListOptional.#.deepDateListOptional': NesoiDate[] | null | undefined
+            // 'pObjListOptional.#.deepDateListOptional.#': NesoiDate | null | undefined
+            // 'pObjListOptional.#.deepDatetimeListOptional': NesoiDatetime[] | null | undefined
+            // 'pObjListOptional.#.deepDatetimeListOptional.#': NesoiDatetime | null | undefined
+            // 'pObjListOptional.#.deepDurationListOptional': NesoiDuration[] | null | undefined
+            // 'pObjListOptional.#.deepDurationListOptional.#': NesoiDuration | null | undefined
+            // 'pObjListOptional.#.deepDecimalListOptional': NesoiDecimal[] | null | undefined
+            // 'pObjListOptional.#.deepDecimalListOptional.#': NesoiDecimal | null | undefined
+            // 'pObjListOptional.#.deepEnumListOptional': ('1' | '2' | '3')[] | null | undefined
+            // 'pObjListOptional.#.deepEnumListOptional.#': ('1' | '2' | '3') | null | undefined
+            // 'pObjListOptional.#.deepIntListOptional': number[] | null | undefined
+            // 'pObjListOptional.#.deepIntListOptional.#': number | null | undefined
+            // 'pObjListOptional.#.deepFloatListOptional': number[] | null | undefined
+            // 'pObjListOptional.#.deepFloatListOptional.#': number | null | undefined
+            // 'pObjListOptional.#.deepStringListOptional': string[] | null | undefined
+            // 'pObjListOptional.#.deepStringListOptional.#': string | null | undefined
+            // 'pObjListOptional.#.deepObjListOptional': {
+            //     'okListOptional'?: boolean[] | null | undefined
+            // }[] | null | undefined
+            // 'pObjListOptional.#.deepObjListOptional.#': {
+            //     'okListOptional'?: boolean[] | null | undefined
+            // } | null | undefined
+            // 'pObjListOptional.#.deepObjListOptional.#.okListOptional': boolean[] | null | undefined
+            // 'pObjListOptional.#.deepObjListOptional.#.okListOptional.#': boolean | null | undefined
+            // 'pDictListOptional': Record<string, number>[] | null | undefined
+            // 'pDictListOptional.#': Record<string, number> | null | undefined
+            // 'pDictListOptional.#.#': number | null | undefined
 
-            'pAnyOptionalArray': any[] | undefined
-            'pAnyOptionalArray.#': any | undefined
-            'pBooleanOptionalArray': boolean[] | undefined
-            'pBooleanOptionalArray.#': boolean | undefined
-            'pDateOptionalArray': NesoiDate[] | undefined
-            'pDateOptionalArray.#': NesoiDate | undefined
-            'pDatetimeOptionalArray': NesoiDatetime[] | undefined
-            'pDatetimeOptionalArray.#': NesoiDatetime | undefined
-            'pDurationOptionalArray': NesoiDuration[] | undefined
-            'pDurationOptionalArray.#': NesoiDuration | undefined
-            'pDecimalOptionalArray': NesoiDecimal[] | undefined
-            'pDecimalOptionalArray.#': NesoiDecimal | undefined
-            'pEnumOptionalArray': ('a' | 'b' | 'c')[] | undefined
-            'pEnumOptionalArray.#': ('a' | 'b' | 'c') | undefined
-            'pIntOptionalArray': number[] | undefined
-            'pIntOptionalArray.#': number | undefined
-            'pFloatOptionalArray': number[] | undefined
-            'pFloatOptionalArray.#': number | undefined
-            'pStringOptionalArray': string[] | undefined
-            'pStringOptionalArray.#': string | undefined
-            'pObjOptionalArray': {
-                'deepBooleanOptionalArray': boolean[] | undefined
-                'deepDateOptionalArray': NesoiDate[] | undefined
-                'deepDatetimeOptionalArray': NesoiDatetime[] | undefined
-                'deepDurationOptionalArray': NesoiDuration[] | undefined
-                'deepDecimalOptionalArray': NesoiDecimal[] | undefined
-                'deepEnumOptionalArray': ('1' | '2' | '3')[] | undefined
-                'deepIntOptionalArray': number[] | undefined
-                'deepFloatOptionalArray': number[] | undefined
-                'deepStringOptionalArray': string[] | undefined
-                'deepObjOptionalArray': {
-                    'okOptionalArray': boolean[] | undefined
-                }[] | undefined
-            }[] | undefined
-            'pObjOptionalArray.#': {
-                'deepBooleanOptionalArray': boolean[] | undefined
-                'deepDateOptionalArray': NesoiDate[] | undefined
-                'deepDatetimeOptionalArray': NesoiDatetime[] | undefined
-                'deepDurationOptionalArray': NesoiDuration[] | undefined
-                'deepDecimalOptionalArray': NesoiDecimal[] | undefined
-                'deepEnumOptionalArray': ('1' | '2' | '3')[] | undefined
-                'deepIntOptionalArray': number[] | undefined
-                'deepFloatOptionalArray': number[] | undefined
-                'deepStringOptionalArray': string[] | undefined
-                'deepObjOptionalArray': {
-                    'okOptionalArray': boolean[] | undefined
-                }[] | undefined
-            } | undefined
-            'pObjOptionalArray.#.deepBooleanOptionalArray': boolean[] | undefined
-            'pObjOptionalArray.#.deepBooleanOptionalArray.#': boolean | undefined
-            'pObjOptionalArray.#.deepDateOptionalArray': NesoiDate[] | undefined
-            'pObjOptionalArray.#.deepDateOptionalArray.#': NesoiDate | undefined
-            'pObjOptionalArray.#.deepDatetimeOptionalArray': NesoiDatetime[] | undefined
-            'pObjOptionalArray.#.deepDatetimeOptionalArray.#': NesoiDatetime | undefined
-            'pObjOptionalArray.#.deepDurationOptionalArray': NesoiDuration[] | undefined
-            'pObjOptionalArray.#.deepDurationOptionalArray.#': NesoiDuration | undefined
-            'pObjOptionalArray.#.deepDecimalOptionalArray': NesoiDecimal[] | undefined
-            'pObjOptionalArray.#.deepDecimalOptionalArray.#': NesoiDecimal | undefined
-            'pObjOptionalArray.#.deepEnumOptionalArray': ('1' | '2' | '3')[] | undefined
-            'pObjOptionalArray.#.deepEnumOptionalArray.#': ('1' | '2' | '3') | undefined
-            'pObjOptionalArray.#.deepIntOptionalArray': number[] | undefined
-            'pObjOptionalArray.#.deepIntOptionalArray.#': number | undefined
-            'pObjOptionalArray.#.deepFloatOptionalArray': number[] | undefined
-            'pObjOptionalArray.#.deepFloatOptionalArray.#': number | undefined
-            'pObjOptionalArray.#.deepStringOptionalArray': string[] | undefined
-            'pObjOptionalArray.#.deepStringOptionalArray.#': string | undefined
-            'pObjOptionalArray.#.deepObjOptionalArray': {
-                'okOptionalArray': boolean[] | undefined
-            }[] | undefined
-            'pObjOptionalArray.#.deepObjOptionalArray.#': {
-                'okOptionalArray': boolean[] | undefined
-            } | undefined
-            'pObjOptionalArray.#.deepObjOptionalArray.#.okOptionalArray': boolean[] | undefined
-            'pObjOptionalArray.#.deepObjOptionalArray.#.okOptionalArray.#': boolean | undefined
-            'pDictOptionalArray': Record<string, number>[] | undefined
-            'pDictOptionalArray.#': Record<string, number> | undefined
-            'pDictOptionalArray.#.#': number | undefined
+            // 'pAnyOptionalList': (any | null | undefined)[]
+            // 'pAnyOptionalList.#': any | null | undefined
+            // 'pBooleanOptionalList': (boolean | null | undefined)[]
+            // 'pBooleanOptionalList.#': boolean | null | undefined
+            // 'pDateOptionalList': (NesoiDate | null | undefined)[]
+            // 'pDateOptionalList.#': NesoiDate | null | undefined
+            // 'pDatetimeOptionalList': (NesoiDatetime | null | undefined)[]
+            // 'pDatetimeOptionalList.#': NesoiDatetime | null | undefined
+            // 'pDurationOptionalList': (NesoiDuration | null | undefined)[]
+            // 'pDurationOptionalList.#': NesoiDuration | null | undefined
+            // 'pDecimalOptionalList': (NesoiDecimal | null | undefined)[]
+            // 'pDecimalOptionalList.#': NesoiDecimal | null | undefined
+            // 'pEnumOptionalList': (('a' | 'b' | 'c') | null | undefined)[]
+            // 'pEnumOptionalList.#': ('a' | 'b' | 'c') | null | undefined
+            // 'pIntOptionalList': (number | null | undefined)[]
+            // 'pIntOptionalList.#': number | null | undefined
+            // 'pFloatOptionalList': (number | null | undefined)[]
+            // 'pFloatOptionalList.#': number | null | undefined
+            // 'pStringOptionalList': (string | null | undefined)[]
+            // 'pStringOptionalList.#': string | null | undefined
+            // 'pObjOptionalList': ({
+            //     'deepBooleanOptionalList'?: (boolean | null | undefined)[]
+            //     'deepDateOptionalList'?: (NesoiDate | null | undefined)[]
+            //     'deepDatetimeOptionalList'?: (NesoiDatetime | null | undefined)[]
+            //     'deepDurationOptionalList'?: (NesoiDuration | null | undefined)[]
+            //     'deepDecimalOptionalList'?: (NesoiDecimal | null | undefined)[]
+            //     'deepEnumOptionalList'?: (('1' | '2' | '3') | null | undefined)[]
+            //     'deepIntOptionalList'?: (number | null | undefined)[]
+            //     'deepFloatOptionalList'?: (number | null | undefined)[]
+            //     'deepStringOptionalList'?: (string | null | undefined)[]
+            //     'deepObjOptionalList'?: ({
+            //         'okOptionalList'?: (boolean | null | undefined)[]
+            //     } | null | undefined)[]
+            // } | null | undefined)[]
+            // 'pObjOptionalList.#': {
+            //     'deepBooleanOptionalList'?: (boolean | null | undefined)[]
+            //     'deepDateOptionalList'?: (NesoiDate | null | undefined)[]
+            //     'deepDatetimeOptionalList'?: (NesoiDatetime | null | undefined)[]
+            //     'deepDurationOptionalList'?: (NesoiDuration | null | undefined)[]
+            //     'deepDecimalOptionalList'?: (NesoiDecimal | null | undefined)[]
+            //     'deepEnumOptionalList'?: (('1' | '2' | '3') | null | undefined)[]
+            //     'deepIntOptionalList'?: (number | null | undefined)[]
+            //     'deepFloatOptionalList'?: (number | null | undefined)[]
+            //     'deepStringOptionalList'?: (string | null | undefined)[]
+            //     'deepObjOptionalList'?: ({
+            //         'okOptionalList'?: (boolean | null | undefined)[]
+            //     } | null | undefined)[]
+            // } | null | undefined
+            // 'pObjOptionalList.#.deepBooleanOptionalList': (boolean | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepBooleanOptionalList.#': boolean | null | undefined
+            // 'pObjOptionalList.#.deepDateOptionalList': (NesoiDate | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepDateOptionalList.#': NesoiDate | null | undefined
+            // 'pObjOptionalList.#.deepDatetimeOptionalList': (NesoiDatetime | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepDatetimeOptionalList.#': NesoiDatetime | null | undefined
+            // 'pObjOptionalList.#.deepDurationOptionalList': (NesoiDuration | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepDurationOptionalList.#': NesoiDuration | null | undefined
+            // 'pObjOptionalList.#.deepDecimalOptionalList': (NesoiDecimal | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepDecimalOptionalList.#': NesoiDecimal | null | undefined
+            // 'pObjOptionalList.#.deepEnumOptionalList': (('1' | '2' | '3') | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepEnumOptionalList.#': ('1' | '2' | '3') | null | undefined
+            // 'pObjOptionalList.#.deepIntOptionalList': (number | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepIntOptionalList.#': number | null | undefined
+            // 'pObjOptionalList.#.deepFloatOptionalList': (number | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepFloatOptionalList.#': number | null | undefined
+            // 'pObjOptionalList.#.deepStringOptionalList': (string | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepStringOptionalList.#': string | null | undefined
+            // 'pObjOptionalList.#.deepObjOptionalList': ({
+            //     'okOptionalList'?: (boolean | null | undefined)[]
+            // } | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepObjOptionalList.#': {
+            //     'okOptionalList'?: (boolean | null | undefined)[]
+            // } | null | undefined
+            // 'pObjOptionalList.#.deepObjOptionalList.#.okOptionalList': (boolean | null | undefined)[] | null | undefined
+            // 'pObjOptionalList.#.deepObjOptionalList.#.okOptionalList.#': boolean | null | undefined
+            // 'pDictOptionalList': (Record<string, number> | null | undefined)[] | null | undefined
+            // 'pDictOptionalList.#': Record<string, number> | null | undefined
+            // 'pDictOptionalList.#.#': number | null | undefined
         }
         views: {
             default: any
@@ -767,26 +802,26 @@ export namespace Mock {
                     okNullable: boolean | null
                 }
             } | null
-            propBooleanArray: boolean[]
-            propDateArray: string[]
-            propDatetimeArray: string[]
-            propDurationArray: string[]
-            propDecimalArray: string[]
-            propEnumArray: ('a' | 'b' | 'c')[]
-            propIdArray_id: Mock.MockBucket['#data']['id'][]
-            propIntArray: number[]
-            propStringArray: string[]
-            propObjArray: {
+            propBooleanList: boolean[]
+            propDateList: string[]
+            propDatetimeList: string[]
+            propDurationList: string[]
+            propDecimalList: string[]
+            propEnumList: ('a' | 'b' | 'c')[]
+            propIdList_id: Mock.MockBucket['#data']['id'][]
+            propIntList: number[]
+            propStringList: string[]
+            propObjList: {
                 deepBoolean: boolean,
                 deepDate: string,
                 deepDatetime: string,
                 deepDuration: string,
-                deepEnumArray: ('1' | '2' | '3')[]
+                deepEnumList: ('1' | '2' | '3')[]
                 deepId_id: Mock.MockBucket['#data']['id']
                 deepInt: number,
                 deepString: string,
                 deepObj: {
-                    okArray: boolean[]
+                    okList: boolean[]
                 }
             }[]
         }
@@ -859,26 +894,26 @@ export namespace Mock {
                     okNullable: boolean | null
                 }
             } | null
-            propBooleanArray: boolean[]
-            propDateArray: NesoiDate[]
-            propDatetimeArray: NesoiDatetime[]
-            propDurationArray: NesoiDuration[]
-            propDecimalArray: NesoiDecimal[]
-            propEnumArray: ('a' | 'b' | 'c')[]
-            propIdArray: Mock.MockBucket['#data'][]
-            propIntArray: number[]
-            propStringArray: string[]
-            propObjArray: {
+            propBooleanList: boolean[]
+            propDateList: NesoiDate[]
+            propDatetimeList: NesoiDatetime[]
+            propDurationList: NesoiDuration[]
+            propDecimalList: NesoiDecimal[]
+            propEnumList: ('a' | 'b' | 'c')[]
+            propIdList: Mock.MockBucket['#data'][]
+            propIntList: number[]
+            propStringList: string[]
+            propObjList: {
                 deepBoolean: boolean,
                 deepDate: NesoiDate,
                 deepDatetime: NesoiDatetime,
                 deepDuration: NesoiDuration,
-                deepEnumArray: ('1' | '2' | '3')[]
+                deepEnumList: ('1' | '2' | '3')[]
                 deepId: Mock.MockBucket['#data']
                 deepInt: number,
                 deepString: string,
                 deepObj: {
-                    okArray: boolean[]
+                    okList: boolean[]
                 }
             }[]
         }
@@ -888,6 +923,7 @@ export namespace Mock {
 
     export type VanillaJob = Overlay<$Job, {
         name: 'vanilla',
+        '#input': never
     }>
 
     export type MockJob = Overlay<$Job, {

--- a/test-d/query.test-d.ts
+++ b/test-d/query.test-d.ts
@@ -55,11 +55,14 @@ const _Mock = {
         'color contains_any': ['r', 'g'],
         'color present': '',
                 
-        flags: [true],
-        'flags ==': [true],
         'flags contains': true,
         'flags contains_any': [true],
         'flags present': '',
+
+        'flags.*': true,
+        'flags.* ==': true,
+        'flags.* in': [true, false],
+        'flags.* present': '',
 
         'flags.#': true,
         'flags.# ==': true,
@@ -88,11 +91,14 @@ const _Mock = {
         'color not contains_any': ['r', 'g'],
         'color not present': '',
                 
-        'flags not': [true],
-        'flags not ==': [true],
         'flags not contains': true,
         'flags not contains_any': [true],
         'flags not present': '',
+
+        'flags.* not': true,
+        'flags.* not ==': true,
+        'flags.* not in': [true, false],
+        'flags.* not present': '',
 
         'flags.# not': true,
         'flags.# not ==': true,

--- a/test-d/resource.test-d.ts
+++ b/test-d/resource.test-d.ts
@@ -304,26 +304,26 @@ const _Mock = {
                         okNullable: $.boolean.nullable,
                     })
                 }).nullable,
-                propBooleanArray: $.boolean.array,
-                propDateArray: $.date.array,
-                propDatetimeArray: $.datetime.array,
-                propDecimalArray: $.decimal().array,
-                propEnumArray: $.enum(['a', 'b', 'c'] as const).array,
-                propIdArray: $.id('mock').array,
-                propIntArray: $.int.array,
-                propStringArray: $.string.array,
-                propObjArray: $.obj({
+                propBooleanList: $.list($.boolean),
+                propDateList: $.list($.date),
+                propDatetimeList: $.list($.datetime),
+                propDecimalList: $.list($.decimal()),
+                propEnumList: $.list($.enum(['a', 'b', 'c'] as const)),
+                propIdList: $.list($.id('mock')),
+                propIntList: $.list($.int),
+                propStringList: $.list($.string),
+                propObjList: $.list($.obj({
                     deepBoolean: $.boolean,
                     deepDate: $.date,
                     deepDatetime: $.datetime,
-                    deepEnumArray: $.enum(['1', '2', '3'] as const).array,
+                    deepEnumList: $.list($.enum(['1', '2', '3'] as const)),
                     deepId: $.id('mock'),
                     deepInt: $.int,
                     deepString: $.string,
                     deepObj: $.obj({
-                        okArray: $.boolean.array,
+                        okList: $.list($.boolean),
                     })
-                }).array
+                }))
             }))
             .extra($ => {
                 type Message = typeof $.msg
@@ -391,24 +391,24 @@ const _Mock = {
                             okNullable: boolean | null
                         }
                     } | null
-                    propBooleanArray: boolean[]
-                    propDateArray: NesoiDate[]
-                    propDatetimeArray: NesoiDatetime[]
-                    propDecimalArray: NesoiDecimal[]
-                    propEnumArray: ('a' | 'b' | 'c')[]
-                    propIdArray: Mock.MockBucket['#data'][]
-                    propIntArray: number[]
-                    propStringArray: string[]
-                    propObjArray: {
+                    propBooleanList: boolean[]
+                    propDateList: NesoiDate[]
+                    propDatetimeList: NesoiDatetime[]
+                    propDecimalList: NesoiDecimal[]
+                    propEnumList: ('a' | 'b' | 'c')[]
+                    propIdList: Mock.MockBucket['#data'][]
+                    propIntList: number[]
+                    propStringList: string[]
+                    propObjList: {
                         deepBoolean: boolean,
                         deepDate: NesoiDate,
                         deepDatetime: NesoiDatetime,
-                        deepEnumArray: ('1' | '2' | '3')[]
+                        deepEnumList: ('1' | '2' | '3')[]
                         deepId: Mock.MockBucket['#data']
                         deepInt: number,
                         deepString: string,
                         deepObj: {
-                            okArray: boolean[]
+                            okList: boolean[]
                         }
                     }[]
                 }

--- a/test/compiler/compiler_test.ts
+++ b/test/compiler/compiler_test.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'node:crypto';
+import { Compiler } from '~/compiler/compiler';
+
+export class CompilerTest {
+
+    private path: {
+        nesoi: string
+        space: string
+        nesoiFile: string
+        module: string
+    }
+
+    constructor() {
+        const nesoiPath = path.join(process.cwd(), 'build');
+
+        const spacePath = path.join(process.cwd(), 'tmp','test', randomUUID());
+        fs.mkdirSync(spacePath, { recursive: true });
+
+        const nesoiFilePath = path.join(spacePath, 'nesoi.ts');
+        const nesoiFile = ''
+        + 'import { Space } from \'../../../build/lib/engine/space\'\n'
+        + '\n'
+        + 'const Nesoi = new Space<any>(__dirname)\n'
+        + '  .name(\'Test\')\n'
+        + '\n'
+        + 'export default Nesoi\n';
+        fs.writeFileSync(nesoiFilePath, nesoiFile);
+
+        const modulePath = path.join(spacePath, 'modules', 'core')
+        fs.mkdirSync(modulePath, { recursive: true });
+
+        this.path = {
+            nesoi: nesoiPath,
+            space: spacePath,
+            nesoiFile: nesoiFilePath,
+            module: modulePath
+        }
+    }
+
+    cleanup() {
+        fs.rmSync(this.path.space, { force: true, recursive: true });
+    }
+
+    addMessage(template: string, name = 'test') {
+        const msgPath = path.join(this.path.module, `${name}.message.ts`);
+        const msg = ''
+        + 'import nesoi from \'../../nesoi\'\n'
+        + '\n'
+        + `export default nesoi.message('core::${name}')\n`
+        + '  .template($ => ({\n'
+        + template
+        + '  }));'
+        fs.writeFileSync(msgPath, msg);
+    }
+
+    addJob(def: string, name = 'test') {
+        const msgPath = path.join(this.path.module, `${name}.job.ts`);
+        const msg = ''
+        + 'import nesoi from \'../../nesoi\'\n'
+        + '\n'
+        + `export default nesoi.job('core::${name}')\n`
+        + def
+        fs.writeFileSync(msgPath, msg);
+    }
+
+    addBucket(def: string, name = 'test') {
+        const msgPath = path.join(this.path.module, `${name}.bucket.ts`);
+        const msg = ''
+        + 'import nesoi from \'../../nesoi\'\n'
+        + '\n'
+        + `export default nesoi.bucket('core::${name}')\n`
+        + def
+        fs.writeFileSync(msgPath, msg);
+    }
+
+    addResource(def: string, name = 'test') {
+        const msgPath = path.join(this.path.module, `${name}.resource.ts`);
+        const msg = ''
+        + 'import nesoi from \'../../nesoi\'\n'
+        + '\n'
+        + `export default nesoi.resource('core::${name}')\n`
+        + def
+        fs.writeFileSync(msgPath, msg);
+    }
+
+    async compile() {
+        const Nesoi = await import(this.path.nesoiFile).then(i => i.default);
+        await new Compiler(
+            Nesoi,
+            {
+                nesoiPath: this.path.nesoi
+            }
+        ).run();
+    }
+
+    get schema_file() {
+        return {
+            message: (name: string = 'test') => {
+                const msgPath = path.join(this.path.space, '.nesoi', 'core', `message__${name}.ts`);
+                return fs.readFileSync(msgPath).toString();
+            },
+            job: (name: string = 'test') => {
+                const msgPath = path.join(this.path.space, '.nesoi', 'core', `job__${name}.ts`);
+                return fs.readFileSync(msgPath).toString();
+            },
+            bucket: (name: string = 'test') => {
+                const msgPath = path.join(this.path.space, '.nesoi', 'core', `bucket__${name}.ts`);
+                return fs.readFileSync(msgPath).toString();
+            },
+            resource: (name: string = 'test') => {
+                const msgPath = path.join(this.path.space, '.nesoi', 'core', `resource__${name}.ts`);
+                return fs.readFileSync(msgPath).toString();
+            }
+        }
+    }
+
+    get schema() {
+        return {
+            message: async (name: string = 'test') => {
+                const msgPath = path.join(this.path.space, '.nesoi', 'core', `message__${name}.ts`);
+                try {
+                    const r = await import(msgPath)
+                    return r.default;
+                }
+                catch (e) {
+                    console.error(e);
+                    throw e;
+                }
+            },
+            job: async (name: string = 'test') => {
+                const jobPath = path.join(this.path.space, '.nesoi', 'core', `job__${name}.ts`);
+                try {
+                    const r = await import(jobPath)
+                    return r.default;
+                }
+                catch (e) {
+                    console.error(e);
+                    throw e;
+                }
+            },
+            bucket: async (name: string = 'test') => {
+                const bucketPath = path.join(this.path.space, '.nesoi', 'core', `bucket__${name}.ts`);
+                try {
+                    const r = await import(bucketPath)
+                    return r.default;
+                }
+                catch (e) {
+                    console.error(e);
+                    throw e;
+                }
+            },
+            resource: async (name: string = 'test') => {
+                const resourcePath = path.join(this.path.space, '.nesoi', 'core', `resource__${name}.ts`);
+                try {
+                    const r = await import(resourcePath)
+                    return r.default;
+                }
+                catch (e) {
+                    console.error(e);
+                    throw e;
+                }
+            }
+        }
+    }
+
+}

--- a/test/compiler/job.compiler.test.ts
+++ b/test/compiler/job.compiler.test.ts
@@ -1,0 +1,72 @@
+import { CompilerTest } from './compiler_test';
+
+describe('Job Compiler', () => {
+   
+    describe('TypeScript Bridge', () => {
+        
+        it('simple job', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addJob(''
+                    +'  .message(\'\', $ => ({\n'
+                    +'    prop: $.string.rule($ => true)\n'
+                    +'  }))\n'
+                    +'  .assert($ => true)\n'
+                    +'  .extra($ => ({}))\n'
+                    +'  .assert($ => true)\n'
+                    +'  .extra($ => ({}))\n'
+                    +'  .method($ => {})\n'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.job()
+
+                const textMsg = await compiler.schema_file.message();
+                expect(textMsg).not.toContain('TS BRIDGE WARN');
+                
+                const textJob = await compiler.schema_file.job();
+                expect(textJob).not.toContain('TS BRIDGE WARN');
+
+                expect(schema).toEqual({
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    authn: [
+
+                    ],
+                    input: [
+
+                    ],
+                    output: undefined,
+                    '$t': 'job',
+                    extrasAndAsserts: [
+                        {
+                            assert: expect.anything()
+                        },
+                        {
+                            extra: expect.anything()
+                        },
+                        {
+                            assert: expect.anything()
+                        },
+                        {
+                            extra: expect.anything()
+                        }
+                    ],
+                    method: expect.anything(),
+                    scope: undefined,
+                    '#output': undefined as any,
+                    '#authn': undefined as any,
+                    '#input': undefined as never,
+                    '#extra': undefined as any
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+    })
+
+})

--- a/test/compiler/message.compiler.test.ts
+++ b/test/compiler/message.compiler.test.ts
@@ -1,0 +1,618 @@
+import { CompilerTest } from './compiler_test';
+
+describe('Message Compiler', () => {
+   
+    describe('Schemas', () => {
+        
+        it('single field', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.int'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.message()
+    
+                expect(schema).toEqual({
+                    '#parsed': undefined,
+                    '#raw': undefined,
+                    $t: 'message',
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    template: {
+                        $t: 'message.template',
+                        fields: {
+                            p: {
+                                '#parsed': undefined,
+                                '#raw': undefined,
+                                $t: 'message.template.field',
+                                alias: 'p',
+                                children: undefined,
+                                defaultValue: undefined,
+                                meta: {},
+                                name: 'p',
+                                nullable: false,
+                                pathParsed: 'p',
+                                pathRaw: 'p',
+                                required: true,
+                                rules: [],
+                                type: 'int',
+                            }
+                        }
+                    }
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+        it('simple obj', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.obj({\n'
+                    +'    sub1: $.string.as(\'Sub 1\'),\n'
+                    +'    sub2: $.boolean.as(\'Sub 2\'),\n'
+                    +'  }).as(\'The Object\')'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.message()
+    
+                expect(schema).toEqual({
+                    '#parsed': undefined,
+                    '#raw': undefined,
+                    $t: 'message',
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    template: {
+                        $t: 'message.template',
+                        fields: {
+                            p: {
+                                '#parsed': undefined,
+                                '#raw': undefined,
+                                $t: 'message.template.field',
+                                alias: 'The Object',
+                                children: {
+                                    'sub1': {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'Sub 1',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: 'sub1',
+                                        nullable: false,
+                                        pathParsed: 'p.sub1',
+                                        pathRaw: 'p.sub1',
+                                        required: true,
+                                        rules: [],
+                                        type: 'string',
+                                    },
+                                    'sub2': {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'Sub 2',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: 'sub2',
+                                        nullable: false,
+                                        pathParsed: 'p.sub2',
+                                        pathRaw: 'p.sub2',
+                                        required: true,
+                                        rules: [],
+                                        type: 'boolean',
+                                    }
+                                },
+                                defaultValue: undefined,
+                                meta: {},
+                                name: 'p',
+                                nullable: false,
+                                pathParsed: 'p',
+                                pathRaw: 'p',
+                                required: true,
+                                rules: [],
+                                type: 'obj',
+                            }
+                        }
+                    }
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+        it('simple list', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.list($.int.as(\'A List Item\')).as(\'The Whole List\')'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.message()
+    
+                expect(schema).toEqual({
+                    '#parsed': undefined,
+                    '#raw': undefined,
+                    $t: 'message',
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    template: {
+                        $t: 'message.template',
+                        fields: {
+                            p: {
+                                '#parsed': undefined,
+                                '#raw': undefined,
+                                $t: 'message.template.field',
+                                alias: 'The Whole List',
+                                children: {
+                                    '#': {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'A List Item',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: '#',
+                                        nullable: false,
+                                        pathParsed: 'p.#',
+                                        pathRaw: 'p.#',
+                                        required: true,
+                                        rules: [],
+                                        type: 'int',
+                                    }
+                                },
+                                defaultValue: undefined,
+                                meta: {},
+                                name: 'p',
+                                nullable: false,
+                                pathParsed: 'p',
+                                pathRaw: 'p',
+                                required: true,
+                                rules: [],
+                                type: 'list',
+                            }
+                        }
+                    }
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+        it('simple dict', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.dict($.int.as(\'A Dict Item\')).as(\'The Whole Dict\')'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.message()
+    
+                expect(schema).toEqual({
+                    '#parsed': undefined,
+                    '#raw': undefined,
+                    $t: 'message',
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    template: {
+                        $t: 'message.template',
+                        fields: {
+                            p: {
+                                '#parsed': undefined,
+                                '#raw': undefined,
+                                $t: 'message.template.field',
+                                alias: 'The Whole Dict',
+                                children: {
+                                    '#': {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'A Dict Item',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: '#',
+                                        nullable: false,
+                                        pathParsed: 'p.#',
+                                        pathRaw: 'p.#',
+                                        required: true,
+                                        rules: [],
+                                        type: 'int',
+                                    }
+                                },
+                                defaultValue: undefined,
+                                meta: {},
+                                name: 'p',
+                                nullable: false,
+                                pathParsed: 'p',
+                                pathRaw: 'p',
+                                required: true,
+                                rules: [],
+                                type: 'dict',
+                            }
+                        }
+                    }
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+        it('simple union', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.union($.int.as(\'Some Int\'), $.boolean.as(\'Some Bool\')).as(\'The Union\')'
+                );
+    
+                await compiler.compile()
+                const schema = await compiler.schema.message()
+    
+                expect(schema).toEqual({
+                    '#parsed': undefined,
+                    '#raw': undefined,
+                    $t: 'message',
+                    module: 'core',
+                    name: 'test',
+                    alias: 'test',
+                    template: {
+                        $t: 'message.template',
+                        fields: {
+                            p: {
+                                '#parsed': undefined,
+                                '#raw': undefined,
+                                $t: 'message.template.field',
+                                alias: 'The Union',
+                                children: {
+                                    0: {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'Some Int',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: 'p',
+                                        nullable: false,
+                                        pathParsed: 'p',
+                                        pathRaw: 'p',
+                                        required: true,
+                                        rules: [],
+                                        type: 'int',
+                                    },
+                                    1: {
+                                        '#parsed': undefined,
+                                        '#raw': undefined,
+                                        $t: 'message.template.field',
+                                        alias: 'Some Bool',
+                                        children: undefined,
+                                        defaultValue: undefined,
+                                        meta: {},
+                                        name: 'p',
+                                        nullable: false,
+                                        pathParsed: 'p',
+                                        pathRaw: 'p',
+                                        required: true,
+                                        rules: [],
+                                        type: 'boolean',
+                                    }
+                                },
+                                defaultValue: undefined,
+                                meta: {},
+                                name: 'p',
+                                nullable: false,
+                                pathParsed: 'p',
+                                pathRaw: 'p',
+                                required: true,
+                                rules: [],
+                                type: 'union',
+                            }
+                        }
+                    }
+                })
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+    })
+
+    describe('TypeScript Bridge', () => {
+
+        it('simple rule', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.int.rule($ => true)'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('rule inside obj', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.obj({\n'
+                    +'    a: $.int.rule($ => true)\n'
+                    +'  })'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!.a.rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('rule inside list', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.list(\n'
+                    +'    $.int.rule($ => true)\n'
+                    +'  )'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['#'].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('rule inside dict', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.dict(\n'
+                    +'    $.int.rule($ => true)\n'
+                    +'  )'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['#'].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('rule inside union', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.union(\n'
+                    +'    $.int,\n'
+                    +'    $.boolean.rule($ => true)\n'
+                    +'  )'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children![0].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children![1].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('rule from external message', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  b: $.int.rule($ => true)\n'
+                , 'base');
+                compiler.addMessage(''
+                    +'  p: $.msg(\'base\')'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['b'].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+
+        it('deep rule', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  p: $.obj({\n'
+                    +'    a: $.list(\n'
+                    +'      $.dict(\n'
+                    +'        $.union(\n'
+                    +'          $.int,\n'
+                    +'          $.string.rule($ => true)\n'
+                    +'        )\n'
+                    +'      )\n'
+                    +'    )\n'
+                    +'  })\n'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['a'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['a'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['a'].children!['#'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['a'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['a'].children!['#'].children!['#'].children![1].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+        it('deep external rule', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addMessage(''
+                    +'  b: $.obj({\n'
+                    +'    y: $.list(\n'
+                    +'      $.dict(\n'
+                    +'        $.union(\n'
+                    +'          $.int,\n'
+                    +'          $.string.rule($ => true)\n'
+                    +'        )\n'
+                    +'      )\n'
+                    +'    )\n'
+                    +'  })\n'
+                , 'base');
+                compiler.addMessage(''
+                    +'  p: $.obj({\n'
+                    +'    x: $.list(\n'
+                    +'      $.dict(\n'
+                    +'        $.union(\n'
+                    +'          $.int,\n'
+                    +'          $.msg(\'base\')\n'
+                    +'        )\n'
+                    +'      )\n'
+                    +'    )\n'
+                    +'  })\n'
+                );
+    
+                await compiler.compile()
+
+                const schema = await compiler.schema.message()    
+                expect(schema.template.fields.p.rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![1].rules).toHaveLength(1);
+
+                const text = await compiler.schema_file.message();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+    })
+
+})

--- a/test/compiler/resource.compiler.test.ts
+++ b/test/compiler/resource.compiler.test.ts
@@ -1,0 +1,249 @@
+import { CompilerTest } from './compiler_test';
+
+describe('Resource Compiler', () => {
+   
+    describe('TypeScript Bridge', () => {
+        
+        it('simple resource', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addBucket(''
+                    +'  .model($ => ({\n'
+                    +'    id: $.int,\n'
+                    +'    prop1: $.string,\n'
+                    +'    prop2: $.list($.string),\n'
+                    +'    prop3: $.list($.obj({\n'
+                    +'      a: $.string'
+                    +'    }))\n'
+                    +'  }))\n'
+                );
+                compiler.addResource(''
+                    +'  .bucket(\'test\')\n'
+                    +'  .create($ => $\n'
+                    +'    .input($ => ({\n'
+                    +'      prop1: $.string.rule($ => true),\n'
+                    +'      prop2: $.list($.string.rule($ => true)),\n'
+                    +'      prop3: $.list($.obj({\n'
+                    +'        a: $.string.rule($ => true)\n'
+                    +'      }))\n'
+                    +'    }))\n'
+                    +'    .prepare($ => $.msg)\n'
+                    +'  )\n'
+                );
+    
+                await compiler.compile()
+
+                const textMsgCreate = await compiler.schema_file.message('test.create');
+                expect(textMsgCreate).not.toContain('TS BRIDGE WARN');
+
+                const textJobCreate = await compiler.schema_file.job('test.create');
+                expect(textJobCreate).not.toContain('TS BRIDGE WARN');
+                
+                const text = await compiler.schema_file.resource();
+                expect(text).not.toContain('TS BRIDGE WARN');
+
+                const schema = await compiler.schema.resource()
+    
+                // expect(schema).toEqual({
+                //     module: 'core',
+                //     name: 'test',
+                //     alias: 'test',
+                //     authn: [
+
+                //     ],
+                //     input: [
+
+                //     ],
+                //     output: undefined,
+                //     '$t': 'job',
+                //     extrasAndAsserts: [
+                //         {
+                //             assert: expect.anything()
+                //         },
+                //         {
+                //             extra: expect.anything()
+                //         }
+                //     ],
+                //     method: ($ => {}) as (...args: any[]) => any,
+                //     scope: undefined,
+                //     '#output': undefined as any,
+                //     '#authn': undefined as any,
+                //     '#input': undefined as never,
+                //     '#extra': undefined as any
+                // })
+ 
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+
+
+        it('deep external rule', async () => {
+            const compiler = new CompilerTest();
+    
+            try {
+                compiler.addBucket(''
+                    +'  .model($ => ({\n'
+                    +'    id: $.int,\n'
+                    +'    p: $.any\n'
+                    +'  }))\n'
+                );
+                compiler.addMessage(''
+                    +'  b: $.obj({\n'
+                    +'    y: $.list(\n'
+                    +'      $.dict(\n'
+                    +'        $.union(\n'
+                    +'          $.int,\n'
+                    +'          $.string.rule($ => true)\n'
+                    +'        )\n'
+                    +'      )\n'
+                    +'    )\n'
+                    +'  })\n'
+                , 'base');
+                compiler.addResource(''
+                    +'  .bucket(\'test\')\n'
+                    +'  .create($ => $\n'
+                    +'    .input($ => ({\n'
+                    +'      p: $.obj({\n'
+                    +'        x: $.list(\n'
+                    +'          $.dict(\n'
+                    +'            $.union(\n'
+                    +'              $.int,\n'
+                    +'              $.msg(\'base\')\n'
+                    +'            )\n'
+                    +'          )\n'
+                    +'        )\n'
+                    +'      })\n'
+                    +'    }))\n'
+                    +'    .prepare($ => $.msg)\n'
+                    +'    .after($ => {})\n'
+                    +'  )\n'
+                    +'  .update($ => $\n'
+                    +'    .input($ => ({\n'
+                    +'      p: $.obj({\n'
+                    +'        x: $.list(\n'
+                    +'          $.dict(\n'
+                    +'            $.union(\n'
+                    +'              $.int,\n'
+                    +'              $.msg(\'base\')\n'
+                    +'            )\n'
+                    +'          )\n'
+                    +'        )\n'
+                    +'      })\n'
+                    +'    }))\n'
+                    +'    .prepare($ => $.msg)\n'
+                    +'    .after($ => {})\n'
+                    +'  )\n'
+                    +'  .delete($ => $\n'
+                    +'    .input($ => ({\n'
+                    +'      p: $.obj({\n'
+                    +'        x: $.list(\n'
+                    +'          $.dict(\n'
+                    +'            $.union(\n'
+                    +'              $.int,\n'
+                    +'              $.msg(\'base\')\n'
+                    +'            )\n'
+                    +'          )\n'
+                    +'        )\n'
+                    +'      })\n'
+                    +'    }))\n'
+                    +'    .prepare($ => true)\n'
+                    +'    .after($ => {})\n'
+                    +'  )\n'
+                );
+    
+                await compiler.compile()
+
+                const textMsgBase = await compiler.schema_file.message('base');
+                expect(textMsgBase).not.toContain('TS BRIDGE WARN');
+
+                {
+                    const textMsg = await compiler.schema_file.message('test.create');
+                    expect(textMsg).not.toContain('TS BRIDGE WARN');
+    
+                    const textJob = await compiler.schema_file.job('test.create');
+                    expect(textJob).not.toContain('TS BRIDGE WARN');
+    
+                    const textResource = await compiler.schema_file.resource();
+                    expect(textResource).not.toContain('TS BRIDGE WARN');
+    
+                    const schema = await compiler.schema.message('test.create')    
+                    expect(schema.template.fields.p.rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![1].rules).toHaveLength(1);
+                }
+
+                {
+                    const textMsg = await compiler.schema_file.message('test.update');
+                    expect(textMsg).not.toContain('TS BRIDGE WARN');
+    
+                    const textJob = await compiler.schema_file.job('test.update');
+                    expect(textJob).not.toContain('TS BRIDGE WARN');
+    
+                    const textResource = await compiler.schema_file.resource();
+                    expect(textResource).not.toContain('TS BRIDGE WARN');
+    
+                    const schema = await compiler.schema.message('test.update')    
+                    expect(schema.template.fields.p.rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![1].rules).toHaveLength(1);
+                }
+
+                {
+                    const textMsg = await compiler.schema_file.message('test.delete');
+                    expect(textMsg).not.toContain('TS BRIDGE WARN');
+    
+                    const textJob = await compiler.schema_file.job('test.delete');
+                    expect(textJob).not.toContain('TS BRIDGE WARN');
+    
+                    const textResource = await compiler.schema_file.resource();
+                    expect(textResource).not.toContain('TS BRIDGE WARN');
+    
+                    const schema = await compiler.schema.message('test.delete')    
+                    expect(schema.template.fields.p.rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![0].rules).toHaveLength(0);
+                    expect(schema.template.fields.p.children!['x'].children!['#'].children!['#'].children![1].children!['b'].children!['y'].children!['#'].children!['#'].children![1].rules).toHaveLength(1);
+                }
+
+            }
+            catch(e) {
+                console.error(e);
+                throw e;
+            }
+            finally {
+                compiler.cleanup();
+            }
+        }, 30000)
+        
+    })
+
+})

--- a/test/elements/bucket.test.ts
+++ b/test/elements/bucket.test.ts
@@ -1,114 +1,743 @@
 import { Log } from '~/engine/util/log'
 import { $id, AnyBucket, Bucket } from '~/elements/entities/bucket/bucket';
+import { expectBucket } from 'nesoi/tools/joaquin/bucket';
+import { Mock } from './mock';
 
 Log.level = 'off';
 
 describe('Bucket', () => {
 
-    describe('Create', () => {
+    describe('Replace Future ID', () => {
 
-        describe('Replace Future ID', () => {
+        const bucket = new Bucket({} as any, {} as any);
+        const replaceFutureId = (bucket as any).replaceFutureId.bind(bucket) as AnyBucket['replaceFutureId'];
 
-            const bucket = new Bucket({} as any, {} as any);
-            const replaceFutureId = (bucket as any).replaceFutureId.bind(bucket) as AnyBucket['replaceFutureId'];
-
-            it('should replace id on object', async() => {
-                // given
-                const obj = {
+        it('should replace id on object', async() => {
+            // given
+            const obj = {
+                future_id: $id,
+                number: 12.34,
+                string: 'string',
+                boolean: true,
+                other_future_id: $id,
+                nested: {
                     future_id: $id,
                     number: 12.34,
                     string: 'string',
                     boolean: true,
                     other_future_id: $id,
-                    nested: {
+                    deep_nested: {
                         future_id: $id,
                         number: 12.34,
                         string: 'string',
                         boolean: true,
                         other_future_id: $id,
-                        deep_nested: {
-                            future_id: $id,
-                            number: 12.34,
-                            string: 'string',
-                            boolean: true,
-                            other_future_id: $id,
-                        }
-                    },
-                    array: [
+                    }
+                },
+                array: [
+                    $id,
+                    12.34,
+                    'string',
+                    true,
+                    $id,
+                    [
                         $id,
                         12.34,
                         'string',
                         true,
+                        $id
+                    ]
+                ],
+                mixed: {
+                    future_id: $id,
+                    array: [
                         $id,
-                        [
-                            $id,
-                            12.34,
-                            'string',
-                            true,
-                            $id
-                        ]
-                    ],
-                    mixed: {
-                        future_id: $id,
-                        array: [
-                            $id,
-                            {
-                                future_id: $id
-                            }
-                        ]
-                    }
+                        {
+                            future_id: $id
+                        }
+                    ]
                 }
-                // when
-                replaceFutureId(obj, 999);
-                // then
-                expect(obj).toEqual({
+            }
+            // when
+            replaceFutureId(obj, 999);
+            // then
+            expect(obj).toEqual({
+                future_id: 999,
+                number: 12.34,
+                string: 'string',
+                boolean: true,
+                other_future_id: 999,
+                nested: {
                     future_id: 999,
                     number: 12.34,
                     string: 'string',
                     boolean: true,
                     other_future_id: 999,
-                    nested: {
+                    deep_nested: {
                         future_id: 999,
                         number: 12.34,
                         string: 'string',
                         boolean: true,
                         other_future_id: 999,
-                        deep_nested: {
-                            future_id: 999,
-                            number: 12.34,
-                            string: 'string',
-                            boolean: true,
-                            other_future_id: 999,
-                        }
-                    },
-                    array: [
+                    }
+                },
+                array: [
+                    999,
+                    12.34,
+                    'string',
+                    true,
+                    999,
+                    [
                         999,
                         12.34,
                         'string',
                         true,
+                        999
+                    ]
+                ],
+                mixed: {
+                    future_id: 999,
+                    array: [
                         999,
-                        [
-                            999,
-                            12.34,
-                            'string',
-                            true,
-                            999
-                        ]
-                    ],
-                    mixed: {
-                        future_id: 999,
-                        array: [
-                            999,
-                            {
-                                future_id: 999
-                            }
-                        ]
-                    }
-                })
+                        {
+                            future_id: 999
+                        }
+                    ]
+                }
             })
-
         })
 
+    })
+
+    describe('View', () => {
+
+        it('should parse view with primitive model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    name: $.string,
+                    height: $.float
+                }))
+                .view('default', $ => ({
+                    built_name: $.model('name'),
+                    other_name: $.model('name'),
+                    height: $.model('height')
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    name: Mock.String,
+                    height: Mock.Float
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    built_name: Mock.String,
+                    other_name: Mock.String,
+                    height: Mock.Float
+                })
+        })
+
+        it('should parse view with list model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.list($.string)
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: [Mock.String, Mock.String]
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: [Mock.String, Mock.String],
+                    tags_all: [Mock.String, Mock.String]
+                })
+        })
+
+        it('should parse view with dict model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.dict($.string)
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: { a: Mock.String, b: Mock.String }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: { a: Mock.String, b: Mock.String },
+                    tags_all: { a: Mock.String, b: Mock.String }
+                })
+        })
+
+        it('should parse view with complex union fields (1)', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    chaos: $.union(
+                        $.obj({ a: $.int, b: $.string }),
+                        $.dict($.boolean),
+                        $.list($.decimal())
+                    )
+                }))
+                .view('default', $ => ({
+                    chaos: $.model('chaos'),
+                    items: $.model('chaos.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    chaos: { a: Mock.String, b: Mock.String }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    chaos: { a: Mock.String, b: Mock.String },
+                    items: { a: Mock.String, b: Mock.String }
+                })
+        })
+        it('should parse view with complex union fields (2)', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    chaos: $.union(
+                        $.obj({ a: $.int, b: $.string }),
+                        $.dict($.boolean),
+                        $.list($.decimal())
+                    )
+                }))
+                .view('default', $ => ({
+                    chaos: $.model('chaos'),
+                    items: $.model('chaos.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    chaos: { c: Mock.Bool }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    chaos: { c: Mock.Bool },
+                    items: { c: Mock.Bool }
+                })
+        })
+        it('should parse view with complex union fields (3)', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    chaos: $.union(
+                        $.obj({ a: $.int, b: $.string }),
+                        $.dict($.boolean),
+                        $.list($.decimal())
+                    )
+                }))
+                .view('default', $ => ({
+                    chaos: $.model('chaos'),
+                    items: $.model('chaos.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    chaos: [ Mock.Decimal, Mock.Decimal ]
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    chaos: [ Mock.Decimal, Mock.Decimal ],
+                    items: [ Mock.Decimal, Mock.Decimal ]
+                })
+        })
+            
+        it('should parse view with list of objects model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.list($.obj({
+                        a: $.string,
+                        b: $.string
+                    }))
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                    tags_all_all: $.model('tags.*.*'),
+                    tags_all_a: $.model('tags.*.a'),
+                    tags_all_b: $.model('tags.*.b'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: [
+                        { a: 'A1', b: 'B1' },
+                        { a: 'A2', b: 'B2' }
+                    ]
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: [
+                        { a: 'A1', b: 'B1' },
+                        { a: 'A2', b: 'B2' }
+                    ],
+                    tags_all: [
+                        { a: 'A1', b: 'B1' },
+                        { a: 'A2', b: 'B2' }
+                    ],
+                    tags_all_all: [
+                        { a: 'A1', b: 'B1' },
+                        { a: 'A2', b: 'B2' }
+                    ],
+                    tags_all_a: [
+                        'A1',
+                        'A2'
+                    ],
+                    tags_all_b: [
+                        'B1',
+                        'B2'
+                    ],
+                })
+        })
+        
+        it('should parse view with list of dicts model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.list($.dict($.string))
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                    tags_all_all: $.model('tags.*.*'),
+                    tags_all_a: $.model('tags.*.a'),
+                    tags_all_b: $.model('tags.*.b'),
+                    tags_all_c: $.model('tags.*.c'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: [
+                        { a: 'A1', b: 'B1' },
+                        { b: 'B2', c: 'C2' }
+                    ]
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: [
+                        { a: 'A1', b: 'B1' },
+                        { b: 'B2', c: 'C2' }
+                    ],
+                    tags_all: [
+                        { a: 'A1', b: 'B1' },
+                        { b: 'B2', c: 'C2' }
+                    ],
+                    tags_all_all: [
+                        { a: 'A1', b: 'B1' },
+                        { b: 'B2', c: 'C2' }
+                    ],
+                    tags_all_a: [
+                        'A1',
+                        undefined
+                    ],
+                    tags_all_b: [
+                        'B1',
+                        'B2'
+                    ],
+                    tags_all_c: [
+                        undefined,
+                        'C2'
+                    ],
+                })
+        })
+        
+        it('should parse view with object of list model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.obj({
+                        a: $.list($.string),
+                        b: $.list($.string)
+                    })
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                    tags_a: $.model('tags.a'),
+                    tags_b: $.model('tags.b'),
+                    tags_a_all: $.model('tags.a.*'),
+                    tags_b_all: $.model('tags.b.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    },
+                    tags_all: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    },
+                    tags_a: ['A1', 'A2'],
+                    tags_a_all: ['A1', 'A2'],
+                    tags_b: ['B1', 'B2'],
+                    tags_b_all: ['B1', 'B2'],
+                })
+        })
+        
+        it('should parse view with dict of list model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.dict($.list($.string))
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                    tags_a: $.model('tags.a'),
+                    tags_b: $.model('tags.b'),
+                    tags_c: $.model('tags.c'),
+                    tags_a_all: $.model('tags.a.*'),
+                    tags_b_all: $.model('tags.b.*'),
+                    tags_c_all: $.model('tags.c.*'),
+                    tags_all_all: $.model('tags.*.*'),
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    },
+                    tags_all: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    },
+                    tags_a: ['A1', 'A2'],
+                    tags_b: ['B1', 'B2'],
+                    tags_c: undefined,
+                    tags_a_all: ['A1', 'A2'],
+                    tags_b_all: ['B1', 'B2'],
+                    tags_c_all: undefined,
+                    tags_all_all: {
+                        a: ['A1', 'A2'],
+                        b: ['B1', 'B2']
+                    }
+                })
+        })
+        
+        it('should parse view with dict of object model fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    tags: $.dict($.obj({
+                        x: $.string,
+                        y: $.string
+                    }))
+                }))
+                .view('default', $ => ({
+                    tags: $.model('tags'),
+                    tags_all: $.model('tags.*'),
+                    tags_all_all: $.model('tags.*.*'),
+                    tags_a: $.model('tags.a'),
+                    tags_b: $.model('tags.b'),
+                    tags_c: $.model('tags.c'),
+                    tags_a_all: $.model('tags.a.*'),
+                    tags_b_all: $.model('tags.b.*'),
+                    tags_c_all: $.model('tags.c.*'),
+                    tags_a_x: $.model('tags.a.x'),
+                    tags_b_y: $.model('tags.b.y')
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    tags: {
+                        a: { x: 'XA', y: 'YA' },
+                        b: { x: 'XB', y: 'YB' },
+                    }
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    tags: {
+                        a: { x: 'XA', y: 'YA' },
+                        b: { x: 'XB', y: 'YB' },
+                    },
+                    tags_all: {
+                        a: { x: 'XA', y: 'YA' },
+                        b: { x: 'XB', y: 'YB' },
+                    },
+                    tags_all_all: {
+                        a: { x: 'XA', y: 'YA' },
+                        b: { x: 'XB', y: 'YB' },
+                    },
+                    tags_a: { x: 'XA', y: 'YA' },
+                    tags_b: { x: 'XB', y: 'YB' },
+                    tags_c: undefined,
+                    tags_a_all: { x: 'XA', y: 'YA' },
+                    tags_b_all: { x: 'XB', y: 'YB' },
+                    tags_a_x: 'XA',
+                    tags_b_y: 'YB',
+                })
+        })
+
+        it('should parse view with nested model fields - no children, non-obj, empty output', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    list_a: $.list($.string),
+                    list_b: $.list($.string),
+                }))
+                .view('default', $ => ({
+                    list: $.model('list_a.*', {})
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    list_a: ['A1', 'A2'],
+                    list_b: ['B1', 'B2']
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    list: [{}, {}],
+                })
+        })
+
+        it('should parse view with nested model fields - only raw, non-obj, empty output', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    list_a: $.list($.string),
+                    list_b: $.list($.string),
+                }))
+                .view('default', $ => ({
+                    list: $.model('list_a.*', {
+                        ...$.raw()
+                    })
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    list_a: ['A1', 'A2'],
+                    list_b: ['B1', 'B2']
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    list: [{}, {}],
+                })
+        })
+
+        it('should parse view with nested model fields - only raw, non-obj, ignore original', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    list_a: $.list($.string),
+                    list_b: $.list($.string),
+                }))
+                .view('default', $ => ({
+                    list: $.model('list_a.*', {
+                        ...$.raw(),
+                        b: $.model('list_b.$0')
+                    })
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    list_a: ['A1', 'A2'],
+                    list_b: ['B1', 'B2']
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    list: [{ b: 'B1' }, { b: 'B2' }],
+                })
+        })
+
+        it('should parse view with nested model fields - only raw, obj, original output', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    list_a: $.list($.obj({
+                        red: $.string,
+                        blue: $.string
+                    })),
+                    list_b: $.list($.string),
+                }))
+                .view('default', $ => ({
+                    list: $.model('list_a.*', {
+                        ...$.raw()
+                    })
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    list_a: [
+                        { red: 'red1', blue: 'blue1' },
+                        { red: 'red2', blue: 'blue2' }
+                    ],
+                    list_b: ['B1', 'B2']
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    list: [
+                        { red: 'red1', blue: 'blue1' },
+                        { red: 'red2', blue: 'blue2' }
+                    ]
+                })
+        })
+
+        it('should parse view with nested model fields - only raw, non-obj, original output', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    list_a: $.list($.obj({
+                        red: $.string,
+                        blue: $.string
+                    })),
+                    list_b: $.list($.string),
+                }))
+                .view('default', $ => ({
+                    list: $.model('list_a.*', {
+                        ...$.raw(),
+                        b: $.model('list_b.$0')
+                    })
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    list_a: [
+                        { red: 'red1', blue: 'blue1' },
+                        { red: 'red2', blue: 'blue2' }
+                    ],
+                    list_b: ['B1', 'B2']
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    list: [
+                        { red: 'red1', blue: 'blue1', b: 'B1' },
+                        { red: 'red2', blue: 'blue2', b: 'B2' }
+                    ],
+                })
+        })
+
+        it('should parse complex model view', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    games: $.list(
+                        $.obj({
+                            score: $.dict($.float),
+                        })
+                    ),
+                    players: $.dict($.string),
+                    times: $.list(
+                        $.dict($.float)
+                    ),
+                }))
+                .view('default', $ => ({
+                    games: $.model('games.*', {
+                        score: $.model('games.$0.score.*', {
+                            value: $.raw(),
+                            player: $.model('players.$1'),
+                            time: $.model('times.$0.$1')
+                        })
+                    })
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    games: [
+                        { score: { p1: 1, p2: 2 } },
+                        { score: { p1: 3, p2: 4 } },
+                        { score: { p1: 5, p2: 6 } },
+                    ],
+                    players: {
+                        p1: 'Player 1',
+                        p2: 'Player 2'
+                    },
+                    times: [
+                        { p1: 11, p2: 12 },
+                        { p1: 13, p2: 14 },
+                        { p1: 15, p2: 16 },
+                    ]
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    games: [
+                        { score: {
+                            p1: { player: 'Player 1', value: 1, time: 11 },
+                            p2: { player: 'Player 2', value: 2, time: 12 }
+                        } },
+                        { score: {
+                            p1: { player: 'Player 1', value: 3, time: 13 },
+                            p2: { player: 'Player 2', value: 4, time: 14 }
+                        } },
+                        { score: {
+                            p1: { player: 'Player 1', value: 5, time: 15 },
+                            p2: { player: 'Player 2', value: 6, time: 16 }
+                        } },
+                    ],
+                })
+        })
+
+        it('should parse view with computed fields', () => {
+            expectBucket($ => $
+                .model($ => ({
+                    id: $.int,
+                    height: $.float
+                }))
+                .view('default', $ => ({
+                    height: $.computed($ => $.raw.height),
+                    double_height: $.computed($ => $.raw.height*2)
+                }))
+            )
+                .toBuildOne({
+                    id: Mock.Int,
+                    height: Mock.Float
+                }, 'default')
+                .as({
+                    $v: 'default',
+                    id: Mock.Int,
+                    height: Mock.Float,
+                    double_height: Mock.Float*2,
+                })
+        })
     })
 
 })

--- a/test/elements/job.test.ts
+++ b/test/elements/job.test.ts
@@ -47,11 +47,10 @@ describe('Job', () => {
 
         it('should run with inline message', async() => {
             await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.float
-                    }
+                .message('', $ => ({
+                    value: $.float
                 }))
+                .input('@')
                 .method(() => {
                     return 'test_ok'
                 })
@@ -63,50 +62,14 @@ describe('Job', () => {
                 .toResolve(() => 'test_ok')
         })
 
-        it('should run for intrinsic message not declared as input', async() => {
-            await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.int
-                    }
-                }))
-                .method(() => {
-                    return 'test_ok'
-                })
-            )
-                .onRaw({
-                    $: 'test',
-                    value: 4
-                })
-                .toResolve(() => 'test_ok')
-        })
-
-        it('should run for intrinsic message not declared as input, without $', async() => {
-            await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.int
-                    }
-                }))
-                .method(() => {
-                    return 'test_ok'
-                })
-            )
-                .onRaw({
-                    value: 4
-                })
-                .toResolve(() => 'test_ok')
-        })
     })
 
     describe('Extra', () => {
 
         it('js primitives', async() => {
             await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.float
-                    }
+                .message('', $ => ({
+                    value: $.float
                 }))
                 .input('@')
                 .extra($ => ({
@@ -135,10 +98,8 @@ describe('Job', () => {
 
         it('js objects', async() => {
             await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.float
-                    }
+                .message('', $ => ({
+                    value: $.float
                 }))
                 .input('@')
                 .extra($ => ({
@@ -177,10 +138,8 @@ describe('Job', () => {
 
         it('js expressions', async() => {
             await expectJob($ => $
-                .messages($ => ({
-                    '': {
-                        value: $.float
-                    }
+                .message('', $ => ({
+                    value: $.float
                 }))
                 .input('@')
                 .extra($ => ({

--- a/test/elements/message.test.ts
+++ b/test/elements/message.test.ts
@@ -6,6 +6,7 @@ import { NesoiDate } from '~/engine/data/date'
 import { Mock } from './mock';
 import { NesoiDatetime } from '~/engine/data/datetime'
 import { NesoiDuration } from '~/engine/data/duration'
+import { MessageBuilder } from '~/elements/entities/message/message.builder'
 
 Log.level = 'off';
 
@@ -299,6 +300,174 @@ describe('Message', () => {
         })
 
         it('enum, required', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { },
+                    { value: null },
+                    { value: undefined },
+                    { value: '' },
+                ])
+                .butFail(NesoiError.Message.FieldIsRequired)
+        })
+    })
+
+    describe('Msg', () => {
+
+        const peerMsg = new MessageBuilder('test', 'peer')
+        peerMsg.template($ => ({
+            peerValue: $.int
+        }));
+
+        const template: MessageTemplateDef<any, any, any> = $ => ({
+            value: $.msg('peer', {}).as('Msg Field')
+        })
+
+        it('msg, valid value', async() => {
+            await expectMessage(template, [peerMsg])
+                .toParse({
+                    value: {
+                        peerValue: 3
+                    }
+                })
+                .as({
+                    value: {
+                        peerValue: 3
+                    }
+                })
+        })
+
+        it('msg, invalid type', async() => {
+            await expectMessage(template, [peerMsg])
+                .toParseAll([
+                    { value: Mock.Int },
+                    { value: Mock.Float },
+                    { value: Mock.Bool }
+                ])
+                .butFail(NesoiError.Message.InvalidFieldType)
+        })
+
+        it('msg, invalid type on msg', async() => {
+            await expectMessage(template, [peerMsg])
+                .toParse({
+                    value: {
+                        peerValue: 'wrong'
+                    }
+                })
+                .butFail(NesoiError.Message.InvalidFieldType)
+        })
+
+        it('msg, required', async() => {
+            await expectMessage(template, [peerMsg])
+                .toParseAll([
+                    { },
+                    { value: null },
+                    { value: undefined },
+                    { value: '' },
+                ])
+                .butFail(NesoiError.Message.FieldIsRequired)
+        })
+    })
+
+    describe('Simple Dict', () => {
+
+        const template: MessageTemplateDef<any, any, any> = $ => ({
+            value: $.dict($.int).as('Integer Dict')
+        })
+
+        it('Record<string, int>, valid value', async() => {
+            await expectMessage(template)
+                .toParse({ value: { a: Mock.Int, b: Mock.Int } })
+                .as({ value: { a: Mock.Int, b: Mock.Int } })
+        })
+
+        it('Record<string, int>, invalid value', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { value: Mock.Int },
+                    { value: Mock.Float },
+                    { value: Mock.String },
+                    { value: Mock.List },
+                    { value: Mock.Obj },
+                ])
+                .butFail(NesoiError.Message.InvalidFieldType)
+        })
+
+        it('Record<string, int>, required', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { },
+                    { value: null },
+                    { value: undefined },
+                    { value: '' },
+                ])
+                .butFail(NesoiError.Message.FieldIsRequired)
+        })
+    })
+
+    describe('Simple List', () => {
+
+        const template: MessageTemplateDef<any, any, any> = $ => ({
+            value: $.list($.int).as('Integer List')
+        })
+
+        it('int[], valid value', async() => {
+            await expectMessage(template)
+                .toParse({ value: [Mock.Int,Mock.Int] })
+                .as({ value: [Mock.Int,Mock.Int] })
+        })
+
+        it('int[], invalid value', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { value: Mock.Int },
+                    { value: Mock.Float },
+                    { value: Mock.String },
+                    { value: Mock.List },
+                    { value: Mock.Obj },
+                ])
+                .butFail(NesoiError.Message.InvalidFieldType)
+        })
+
+        it('int[], required', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { },
+                    { value: null },
+                    { value: undefined },
+                    { value: '' },
+                ])
+                .butFail(NesoiError.Message.FieldIsRequired)
+        })
+    })
+
+    describe('Simple Union', () => {
+
+        const template: MessageTemplateDef<any, any, any> = $ => ({
+            value: $.union($.int, $.string).as('Integer or String')
+        })
+
+        it('int|string, valid value 1', async() => {
+            await expectMessage(template)
+                .toParse({ value: Mock.Int })
+                .as({ value: Mock.Int })
+        })
+
+        it('int|string, valid value 2', async() => {
+            await expectMessage(template)
+                .toParse({ value: Mock.String })
+                .as({ value: Mock.String })
+        })
+
+        it('int|string, invalid value', async() => {
+            await expectMessage(template)
+                .toParseAll([
+                    { value: Mock.List },
+                    { value: Mock.Obj },
+                ])
+                .butFail(NesoiError.Message.ValueDoesntMatchUnion)
+        })
+
+        it('int|string, required', async() => {
             await expectMessage(template)
                 .toParseAll([
                     { },

--- a/tools/joaquin/mock.ts
+++ b/tools/joaquin/mock.ts
@@ -53,7 +53,10 @@ export class BucketMockObj<$ extends $Bucket, T> {
             }
             else {
                 const field = fields[f];
-                if (field.array) {
+                if (field.type === 'union') {
+                    obj[f] = this.makeUnion(field, overrides?.[f]);
+                }
+                if (field.type === 'list') {
                     obj[f] = this.makeList(field, overrides?.[f]);
                 }
                 else {
@@ -62,6 +65,12 @@ export class BucketMockObj<$ extends $Bucket, T> {
             }
         }
         return obj;
+    }
+
+    private makeUnion(field: $BucketModelField, overrides?: Record<string, any>) {
+        const n = Object.keys(field.children!).length;
+        const r = Math.floor(Math.random()*n);
+        return this.makeField(field.children![r], overrides)
     }
 
     private makeList(field: $BucketModelField, overrides?: Record<string, any>) {
@@ -88,7 +97,7 @@ export class BucketMockObj<$ extends $Bucket, T> {
         else if (field.type === 'dict') {
             const dict: Record<string, any> = {};
             for (let i = 0; i < 3; i++) {
-                dict[Mock.string()] = this.makeField(field.children!.__dict);
+                dict[Mock.string()] = this.makeField(field.children!['#']);
             }
             return dict;
         }
@@ -168,8 +177,8 @@ class MessageMock<
             }
             else {
                 const field = fields[f];
-                if (field.array) {
-                    obj[f] = this.makeList(field, overrides?.[f]);
+                if (field.type === 'list') {
+                    obj[f] = this.makeList(field.children!['#'], overrides?.[f]);
                 }
                 else {
                     obj[f] = this.makeField(field, overrides?.[f]);
@@ -203,7 +212,7 @@ class MessageMock<
         else if (field.type === 'dict') {
             const dict: Record<string, any> = {};
             for (let i = 0; i < 3; i++) {
-                dict[Mock.string()] = this.makeField(field.children!.__dict);
+                dict[Mock.string()] = this.makeField(field.children!['#']);
             }
             return dict;
         }


### PR DESCRIPTION
- `.array` replaced by `.list()` on Message and Bucket builders
- `.or` replaced by  `.union()` on Message and Bucket builders
- "Fieldpaths" replaced by "Modelpaths" and "Querypaths" on Buckets
- `.messages()` replaced by `.message()` for inline messages
- added support for external messages
- improved Typescript Bridge to deal with `.msg()` fields
- allow space-absolute paths for lib imports
- support perPage=0 on NQL
- reimplement bucket view parsing (layer based, no validation)
- basic compiler tests